### PR TITLE
Invalidate static cache when models are updated

### DIFF
--- a/docs/frontend-routing.md
+++ b/docs/frontend-routing.md
@@ -5,6 +5,7 @@ title: 'Front-end Routing'
 Front-end routing is honestly my favourite feature in Runway. It lets you setup front-end routes for your Eloquent models - behind the scenes, it works pretty much the exact same way as it does for entries.
 
 ## Enabling
+
 > Before getting started, ensure you’ve run `php artisan migrate`. Runway comes with a `runway_uris` table which will be used to store all of the front-end URIs.
 
 First things first, add a `route` key to your resource config, with the URI structure you want to use. Feel free to use Antlers in there for anything dynamic, like a slug or a date.
@@ -30,6 +31,7 @@ class Product extends Model
 Last but not least, run `php please runway:rebuild-uris`. This command will essentially loop through all of your models, compile the Antlers URIs, and save it to the database for reference later.
 
 ## Customising the template/layout used
+
 Runway will assume you want to use the `default` template and the `layout` layout for resources.
 
 However, most of the time, you’ll want to change this. To change it, just specify what you want to change them to.
@@ -41,10 +43,10 @@ However, most of the time, you’ll want to change this. To change it, just spec
 'layout' => 'layouts.shop',
 ```
 
-
 ## Available variables
+
 Instead your show/detail view of your model, you’ll have access to a bunch of variables:
 
-* All fields configured in your blueprint (with augmentation of course)
-* Any fields not in your blueprint but configured in your model, like `created_at`, `updated_at`.
-* Any other variables provided by [the Cascade](https://statamic.dev/cascade#content)
+-   All fields configured in your blueprint (with augmentation of course)
+-   Any fields not in your blueprint but configured in your model, like `created_at`, `updated_at`.
+-   Any other variables provided by [the Cascade](https://statamic.dev/cascade#content)

--- a/docs/frontend-routing.md
+++ b/docs/frontend-routing.md
@@ -50,3 +50,28 @@ Instead your show/detail view of your model, you’ll have access to a bunch of 
 -   All fields configured in your blueprint (with augmentation of course)
 -   Any fields not in your blueprint but configured in your model, like `created_at`, `updated_at`.
 -   Any other variables provided by [the Cascade](https://statamic.dev/cascade#content)
+
+## Static Caching Invalidation
+
+If you're taking advantage of Statamic's [Static Caching](https://statamic.dev/static-caching) functionality, you may configure your routed Runway resources to be 'invalidated' on update.
+
+```php
+// config/statamic/static_caching.php
+
+'invalidation' => [
+
+    'class' => null,
+
+    'rules' => [
+        'runway' => [
+            'product' => [
+                'urls' => [
+                    '/products',
+                    '/products/*',
+                ],
+            ],
+        ],
+    ],
+
+],
+```

--- a/src/Routing/Traits/RunwayRoutes.php
+++ b/src/Routing/Traits/RunwayRoutes.php
@@ -7,6 +7,8 @@ use DoubleThreeDigital\Runway\Routing\RoutingModel;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Support\Str;
 use Statamic\Routing\Routable;
+use Statamic\StaticCaching\Cacher;
+use Statamic\Support\Arr;
 use Statamic\View\Antlers\Parser;
 
 trait RunwayRoutes
@@ -95,6 +97,10 @@ trait RunwayRoutes
                     'uri' => $uri,
                 ]);
             }
+
+            app(Cacher::class)->invalidateUrls(
+                Arr::get(config('statamic.static_caching.invalidation.rules'), "runway.{$resource->handle()}.urls")
+            );
         });
 
         static::deleting(function ($model) {


### PR DESCRIPTION
This pull request allows for invalidating parts of the static cache when models are updated.

In your `static_caching.php` config file, do something like this to invalidate specific URLs:

```php
'invalidation' => [

        'class' => null,

        'rules' => [
            'runway' => [
                'product' => [
                    'urls' => [
                        '/products/*',
                    ],
                ],
            ],
        ],

],
```

Closes #166