### PR TITLE
Show Save button on smaller screens

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -73,7 +73,7 @@
         <button
             v-if="!readOnly"
             class="btn-lg btn-primary w-full" 
-            :disabled="!canSave"
+            :disabled="isSaving"
             @click.prevent="save"
         >
             Save

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -68,6 +68,17 @@
         </publish-sections>
       </div>
     </publish-container>
+
+    <div class="md:hidden mt-3 flex items-center">
+        <button
+            v-if="!readOnly"
+            class="btn-lg btn-primary w-full" 
+            :disabled="!canSave"
+            @click.prevent="save"
+        >
+            Save
+        </button>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
This pull request fixes #172 by adding a Save button at the bottom of the publish form for smaller screens.

<img width="672" alt="image" src="https://user-images.githubusercontent.com/19637309/198829399-d25d515e-022a-4666-a058-c1b001335897.png">