### PR TITLE
Wrap strings in Laravel's localisation helper

### DIFF
--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -19,7 +19,7 @@
                     :disabled="isSaving"
                     @click.prevent="save"
                 >
-                    Save
+                    __('Save')
                 </button>
             </div>
         </div>
@@ -83,7 +83,7 @@
                 :disabled="isSaving"
                 @click.prevent="save"
             >
-                Save
+                __('Save')
             </button>
         </div>
     </div>

--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -1,5 +1,7 @@
 @extends('statamic::layout')
-@section('title', "Create {$resource->singular()}")
+@section('title', __('Create :resource', [
+    'resource' => $resource->singular(),
+]))
 @section('wrapper_class', 'max-w-3xl')
 
 @section('content')

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -1,5 +1,7 @@
 @extends('statamic::layout')
-@section('title', "Edit {$resource->singular()}")
+@section('title', __('Edit :resource', [
+    'resource' => $resource->singular(),
+]))
 @section('wrapper_class', 'max-w-3xl')
 
 @section('content')

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -12,7 +12,9 @@
                     class="btn-primary"
                     href="{{ cp_route('runway.create', ['resourceHandle' => $resource->handle()]) }}"
                 >
-                    Create {{ $resource->singular() }}
+                    {{ __('Create :resource', [
+                        'resource' => $resource->singular()
+                    ]) }}
                 </a>
             @endcan
         @endif

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -50,8 +50,8 @@ class BaseFieldtype extends Relationship
                 'width' => 50,
             ],
             'resource' => [
-                'display' => 'Resource',
-                'instructions' => "Select the Runway resource you'd like to be selectable from this field.",
+                'display' => __('Resource'),
+                'instructions' => __("Select the Runway resource you'd like to be selectable from this field."),
                 'type' => 'select',
                 'options' => collect(Runway::allResources())
                     ->mapWithKeys(function ($resource) {
@@ -69,7 +69,7 @@ class BaseFieldtype extends Relationship
             ],
             'with' => [
                 'display' => __('Eager Loaded Relationships'),
-                'instructions' => 'Specify any relationships you wish to be eager loaded when this field is augmented.',
+                'instructions' => __('Specify any relationships you wish to be eager loaded when this field is augmented.'),
                 'type' => 'list',
                 'default' => [],
                 'width' => 50,

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -51,7 +51,7 @@ class ResourceController extends CpController
 
         $viewData = [
             'title' => __('Create :resource', [
-                'resource' => $resource->singular()
+                'resource' => $resource->singular(),
             ]),
             'action' => cp_route('runway.store', ['resourceHandle' => $resource->handle()]),
             'method' => 'POST',
@@ -151,7 +151,7 @@ class ResourceController extends CpController
 
         $viewData = [
             'title' => __('Edit :resource', [
-                'resource' => $resource->singular()
+                'resource' => $resource->singular(),
             ]),
             'action' => cp_route('runway.update', [
                 'resourceHandle'  => $resource->handle(),

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -50,7 +50,9 @@ class ResourceController extends CpController
         $fields = $fields->preProcess();
 
         $viewData = [
-            'title' => "Create {$resource->singular()}",
+            'title' => __('Create :resource', [
+                'resource' => $resource->singular()
+            ]),
             'action' => cp_route('runway.store', ['resourceHandle' => $resource->handle()]),
             'method' => 'POST',
             'breadcrumbs' => new Breadcrumbs([
@@ -148,7 +150,9 @@ class ResourceController extends CpController
         $fields = $blueprint->fields()->addValues($values)->preProcess();
 
         $viewData = [
-            'title' => "Edit {$resource->singular()}",
+            'title' => __('Edit :resource', [
+                'resource' => $resource->singular()
+            ]),
             'action' => cp_route('runway.update', [
                 'resourceHandle'  => $resource->handle(),
                 'record' => $record->{$resource->routeKey()},


### PR DESCRIPTION
This pull request wraps (hopefully all) of the strings you can see from Runway in the Control Panel, in Laravel's localisation helper to allow for users to translate them.

Related: #176 #177