### PR TITLE
Hide bulk delete button for read only resources

### DIFF
--- a/src/Actions/DeleteModel.php
+++ b/src/Actions/DeleteModel.php
@@ -25,7 +25,7 @@ class DeleteModel extends Action
 
     public function visibleToBulk($items)
     {
-        if ($items->whereInstanceOf(Model::class)->count() !== $items->count()) {
+        if ($items->whereInstanceOf(Model::class)->count() !== $items->count() || !$this->visibleTo($items->whereInstanceOf(Model::class)->first())) {
             return false;
         }
 

--- a/src/Actions/DeleteModel.php
+++ b/src/Actions/DeleteModel.php
@@ -25,11 +25,10 @@ class DeleteModel extends Action
 
     public function visibleToBulk($items)
     {
-        if ($items->whereInstanceOf(Model::class)->count() !== $items->count() || !$this->visibleTo($items->whereInstanceOf(Model::class)->first())) {
-            return false;
-        }
-
-        return true;
+        return $items
+            ->map(fn ($item) => $this->visibleTo($item))
+            ->filter(fn ($isVisible) => $isVisible === true)
+            ->count() === $items->count();
     }
 
     public function authorize($user, $item)


### PR DESCRIPTION
This will pick out the first item from the items collection and use the single item visibility function to see if the delete button should be visible.  There might be more elegant ways to this but it seems to do the job and should also be able to handle null and non Model objects. 