### PR TITLE
Runway Fieldtypes: Columns should use a field's 'Display' text, instead of the handle

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -222,6 +222,7 @@ class BaseFieldtype extends Relationship
                 $blueprintField = $blueprint->field($columnKey);
 
                 return Column::make($columnKey)
+                    ->label($blueprintField->display())
                     ->fieldtype($blueprintField->fieldtype()->handle());
             })
             // ->merge([Column::make('title')])


### PR DESCRIPTION
This pull request resolves #185 (an issue when using the Has Many fieldtype in 'Table' mode). 

Previously, if you had a column like `brand_id`, it would show something like 'Brand Id' as the column name (which it shouldn't really be doing).

Instead, this pull request makes it so the field's "Display" text is used (which might be `Brand - more user friendly).

Below is a screenshot on my sandbox site now it's resolved:

![image](https://user-images.githubusercontent.com/19637309/202866288-b7303979-7450-48fc-a689-d47af28bb3a4.png)