### PR TITLE
Fix error with BelongsTo fieldtype when saving via a publish form inside a stack

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -209,9 +209,9 @@ class ResourceController extends CpController
 
         $record->save();
 
+        // In the case of the 'Relationship' fields in Table Mode, when a model is updated
+        // in the stack, we also need to return it's relations.
         if ($request->get('from_inline_publish_form')) {
-            // In the case of the 'Relationship' fields in Table Mode, when a model is updated
-            // in the stack, we also need to return it's relations.
             collect($resource->blueprint()->fields()->all())
                 ->filter(function (Field $field) {
                     return $field->type() === 'belongs_to' || $field->type() === 'has_many';

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -216,12 +216,14 @@ class ResourceController extends CpController
                 ->filter(function (Field $field) {
                     return $field->type() === 'belongs_to' || $field->type() === 'has_many';
                 })
-                ->each(function (Field $field) use (&$record) {
+                ->each(function (Field $field) use (&$record, $resource) {
                     $relatedResource = Runway::findResource($field->get('resource'));
 
                     $column = $relatedResource->listableColumns()[0];
 
-                    $record->{$field->handle()} = $record->{$field->handle()}()
+                    $relationshipName = $resource->eagerLoadingRelations()->get($field->handle()) ?? $field->handle();
+
+                    $record->{$field->handle()} = $record->{$relationshipName}()
                         ->select('id', $column)
                         ->get()
                         ->each(function ($model) use ($relatedResource, $column) {

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -213,8 +213,9 @@ class ResourceController extends CpController
             // In the case of the 'Relationship' fields in Table Mode, when a model is updated
             // in the stack, we also need to return it's relations.
             collect($resource->blueprint()->fields()->all())
-                ->filter(fn (Field $field) => $field->type() === 'belongs_to'
-                    || $field->type() === 'has_many')
+                ->filter(function (Field $field) {
+                    return $field->type() === 'belongs_to' || $field->type() === 'has_many';
+                })
                 ->each(function (Field $field) use (&$record) {
                     $relatedResource = Runway::findResource($field->get('resource'));
 

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -281,6 +281,34 @@ class ResourceControllerTest extends TestCase
         $this->assertSame($post->title, 'Santa is coming home');
     }
 
+    /**
+     * @test
+     * https://github.com/duncanmcclean/runway/issues/187
+     */
+    public function can_update_resource_when_being_updated_from_inline_publish_form()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $post = $this->postFactory();
+
+        $this->actingAs($user)
+            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+                'title' => 'Santa is coming home',
+                'slug' => 'santa-is-coming-home',
+                'body' => $post->body,
+                'author_id' => [$post->author_id],
+                'from_inline_publish_form' => true,
+            ])
+            ->assertOk()
+            ->assertJsonStructure([
+                'data',
+            ]);
+
+        $post->refresh();
+
+        $this->assertSame($post->title, 'Santa is coming home');
+    }
+
     /** @test */
     public function cant_update_resource_if_resource_is_read_only()
     {


### PR DESCRIPTION
This pull request resolves an issue where saving a record via a publish form inside a stack would fail when the resource inside the stack includes a BelongsTo field.

* So say, you had a 'Locations' resource. 
* When editing locations, you can create/edit 'Location Updates'
* The Location Updates resource contains a Belongs To field to any resource
* When saving the Location Update in the stack,  the user would receive an error

Essentially, whenever you save an entry from inside a stack, it's trying to send back the model data & data about the model's relations.

The reason we're returning information about the model's relations is because they might be needed if the Runway fieldtype is in "Table" mode (depending on the listable columns there).

Runway tries to loop through the fields in your blueprint which are either Belongs To or Has Many fields. It attempts to fill them but it's getting the relationship name wrong. In my example, it would try to use the `location_id` relation method which wouldn't work. It should be using the `location` relation method.

I've fixed this by using an existing method Runway includes to map column names -> relationship names. I've also added another test which fails without this fix.

Fixes #187