### PR TITLE
Fix data being encoded by Runway even when a cast is setup

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -114,7 +114,7 @@ class ResourceController extends CpController
             // let's JSON encode it.
             if (
                 is_array($processedValue)
-                && ! $record->hasCast($fieldKey, ['array', 'collection', 'object', 'encrypted:array', 'encrypted:collection', 'encrypted:object'])
+                && ! $record->hasCast($fieldKey, ['json', 'array', 'collection', 'object', 'encrypted:array', 'encrypted:collection', 'encrypted:object'])
             ) {
                 $processedValue = json_encode($processedValue, JSON_THROW_ON_ERROR);
             }
@@ -235,7 +235,7 @@ class ResourceController extends CpController
             // let's JSON encode it.
             if (
                 is_array($processedValue)
-                && ! $record->hasCast($fieldKey, ['array', 'collection', 'object', 'encrypted:array', 'encrypted:collection', 'encrypted:object'])
+                && ! $record->hasCast($fieldKey, ['json', 'array', 'collection', 'object', 'encrypted:array', 'encrypted:collection', 'encrypted:object'])
             ) {
                 $processedValue = json_encode($processedValue, JSON_THROW_ON_ERROR);
             }

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -13,6 +13,7 @@ use DoubleThreeDigital\Runway\Support\Json;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Facades\Scope;
 use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Arr;
 use Statamic\Http\Controllers\CP\CpController;
 
 class ResourceController extends CpController
@@ -101,6 +102,12 @@ class ResourceController extends CpController
                 }
 
                 continue;
+            }
+
+            // If it's a BelongsTo field & the $processedValue is an array, then we
+            // want the first item in the array.
+            if ($field->type() === 'belongs_to' && is_array($processedValue)) {
+                $processedValue = $processedValue[0];
             }
 
             // If the $processedValue is an array & no cast is set on the model then
@@ -216,6 +223,12 @@ class ResourceController extends CpController
             // Skip section & HasMany fields as there's nothing to store.
             if ($field->type() === 'section' || $field->type() === 'has_many') {
                 continue;
+            }
+
+            // If it's a BelongsTo field & the $processedValue is an array, then we
+            // want the first item in the array.
+            if ($field->type() === 'belongs_to' && is_array($processedValue)) {
+                $processedValue = $processedValue[0];
             }
 
             // If the $processedValue is an array & no cast is set on the model then

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -13,7 +13,6 @@ use DoubleThreeDigital\Runway\Support\Json;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Facades\Scope;
 use Statamic\Fields\Field;
-use Statamic\Fieldtypes\Arr;
 use Statamic\Http\Controllers\CP\CpController;
 
 class ResourceController extends CpController


### PR DESCRIPTION
This pull request fixes an issue where Runway would encode an array as JSON, even when a valid cast is setup on the Eloquent model.

For context, this is the model:

```php
protected $casts = [
        'is_paid' => 'boolean',
        'is_shipped' => 'boolean',
        'is_refunded' => 'boolean',
        'items' => 'json',  // This one!
        'grand_total' => 'integer',
        'items_total' => 'integer',
        'tax_total' => 'integer',
        'shipping_total' => 'integer',
        'coupon_total' => 'integer',
        'use_shipping_address_for_billing' => 'boolean',
        'gateway' => 'json',
        'data' => 'json',
        'paid_date' => 'datetime',
];
```

And this was the blueprint issue it was having issues with...

```yaml
- handle: items
        field:
          fields:
            - handle: id
              field:
                type: hidden
                listable: hidden
                display: ID
            - handle: product
              field:
                max_items: 1
                mode: default
                collections:
                  - products
                type: entries
                listable: hidden
                display: Product
                validate: required
                width: 50
            - handle: variant
              field:
                display: Variant
                type: product_variant
                icon: product_variant
                width: 50
                listable: hidden
            - handle: quantity
              field:
                input_type: number
                type: text
                listable: hidden
                display: Quantity
                width: 50
            - handle: total
              field:
                read_only: false
                type: money
                listable: hidden
                display: Total
                validate: required
                width: 50
            - handle: metadata
              field:
                mode: dynamic
                display: Metadata
                type: array
                icon: array
                listable: hidden
            - handle: tax
              field:
                type: sc_line_items_tax
          mode: stacked
          reorderable: false
          type: grid
          listable: false
          display: "Line Items"
          min_rows: 1
          add_row: "Add Line Item"
          read_only: true
```

Fixes duncanmcclean/simple-commerce#789