### PR TITLE
Add `title_field` config option to determine "title" field

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -251,6 +251,21 @@ Sometimes you may want to change the order that your models are returned in the 
 ],
 ```
 
+### Title field
+
+When Runway displays models inside inside the Control Panel (eg. in relationship fields, in search), it'll default to showing the first listable field it can find, based on your blueprint.
+
+If you'd like to specify a different field, you may do so by setting the `title_field` option on your resource.
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+	    'name' => 'Orders',
+		'title_field' => 'name',
+	],
+],
+```
+
 ## Actions
 
 In much the same way with entries, you can create custom Actions which will be usable in the listing tables provided by Runway.

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -143,7 +143,7 @@ class BaseFieldtype extends Relationship
         }
 
         return collect($data)->map(function ($item) use ($resource) {
-            $column = $resource->listableColumns()[0];
+            $column = $resource->titleField();
 
             $fieldtype = $resource->blueprint()->field($column)->fieldtype();
 
@@ -304,7 +304,7 @@ class BaseFieldtype extends Relationship
     protected function makeTitle($record, $resource): string
     {
         if (! $titleFormat = $this->config('title_format')) {
-            $firstListableColumn = $resource->listableColumns()[0];
+            $firstListableColumn = $resource->titleField();
 
             return $record->{$firstListableColumn};
         }

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -199,7 +199,7 @@ class ResourceController extends CpController
             'resourceHasRoutes' => $resource->hasRouting(),
             'currentRecord' => [
                 'id'    => $record->getKey(),
-                'title' => $record->{collect($resource->listableColumns())->first()},
+                'title' => $record->{$resource->titleField()},
                 'edit_url' => $request->url(),
             ],
         ];
@@ -255,7 +255,7 @@ class ResourceController extends CpController
                 ->each(function (Field $field) use (&$record, $resource) {
                     $relatedResource = Runway::findResource($field->get('resource'));
 
-                    $column = $relatedResource->listableColumns()[0];
+                    $column = $relatedResource->titleField();
 
                     $relationshipName = $resource->eagerLoadingRelations()->get($field->handle()) ?? $field->handle();
 
@@ -286,7 +286,7 @@ class ResourceController extends CpController
     protected function getReturnData($resource, $record)
     {
         return array_merge($record->toArray(), [
-            'title' => $record->{$resource->listableColumns()[0]},
+            'title' => $record->{$resource->titleField()},
             'edit_url' => cp_route('runway.edit', [
                 'resourceHandle'  => $resource->handle(),
                 'record' => $record->{$resource->routeKey()},

--- a/src/Http/Controllers/Traits/HasListingColumns.php
+++ b/src/Http/Controllers/Traits/HasListingColumns.php
@@ -11,7 +11,7 @@ trait HasListingColumns
     {
         $preferredFirstColumn = isset(User::current()->preferences()['runway'][$resource->handle()]['columns'])
             ? User::current()->preferences()['runway'][$resource->handle()]['columns'][0]
-            : $resource->listableColumns()[0];
+            : $resource->titleField();
 
         return collect($resource->listableColumns())
             ->map(function ($columnKey) use ($blueprint, $preferredFirstColumn) {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -26,6 +26,7 @@ class Resource
     protected $readOnly;
     protected $eagerLoadingRelations;
     protected $orderBy;
+    protected $titleField;
 
     public function handle($handle = null)
     {
@@ -294,6 +295,14 @@ class Resource
     public function augment(Model $model): array
     {
         return AugmentedRecord::augment($model, $this->blueprint());
+    }
+
+    public function titleField($field = null)
+    {
+        return $this
+            ->fluentlyGetOrSet('titleField')
+            ->getter(fn ($field) => $field ?? $this->listableColumns()[0])
+            ->args(func_get_args());
     }
 
     public function __get($name)

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -30,6 +30,10 @@ class Runway
                     $resource->name(Str::title($handle));
                 }
 
+                if (isset($config['title_field'])) {
+                    $resource->titleField($config['title_field']);
+                }
+
                 if (isset($config['blueprint'])) {
                     $resource->blueprint($config['blueprint']);
                 }


### PR DESCRIPTION
This pull request builds on top of the new `title_field` configuration option added in #200.

Essentially, whenever Runway returns a model in the Control Panel (for example: in a fieldtype or in search), it displays a "title".

Up until now, this title was always the first listable field from the resource's blueprint.

However, this PR refactors all usage of `listableColumns()[0]` to pull the "title" from this new configuration option. If no title field is specified, the first listable field will remain the title that gets used.