### PR TITLE
Drop Nav configuration

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -138,56 +138,17 @@ If you’d like to hide the CP Nav Item that’s registered for this model, just
 
 > Bear in mind, this will just hide the Nav Item for the CP interface, it won’t actually get rid of the routes being registered. If someone knows where to look, they could still use the CP to manage your models (they could guess the URL).
 
-## CP Nav
-
-Runway will automatically register a Control Panel Nav Item for any configured resources (unless they're marked as `hidden`). By default, it'll put them in the 'Content' section and give them a generic icon. However, you may configure various settings for the CP Nav Item if required:
-
-### Icon
+### Control Panel Icon
 
 You should set `icon` to the name of the icon you’d like to use instead.
 
-Alternatively, if the icon you want isn’t [included in Statamic](https://github.com/statamic/cms/tree/3.1/resources/svg), you can also pass an SVG inline.
+Alternatively, if the icon you want isn’t [included in Statamic](https://github.com/statamic/cms/tree/3.1/resources/svg), you can also pass an inline SVG.
 
 ```php
 'resources' => [
 	\App\Models\Order::class => [
 		'name' => 'Orders',
-
-        'nav' => [
-            'icon' => 'date',
-        ],
-	],
-],
-```
-
-### Section
-
-You should set `section` to the name of the section you’d like to use instead.
-
-```php
-'resources' => [
-	\App\Models\Order::class => [
-		'name' => 'Orders',
-
-        'nav' => [
-            'section' => 'Tools',
-        ],
-	],
-],
-```
-
-### Title
-
-You should set `title` to whatever you want the name of the Nav Item to be.
-
-```php
-'resources' => [
-	\App\Models\Order::class => [
-		'name' => 'Orders',
-
-        'nav' => [
-            'title' => 'Shop Orders',
-        ],
+        'cp_icon' => 'date',
 	],
 ],
 ```

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -16,8 +16,6 @@ class Resource
     protected $name;
     protected $blueprint;
     protected $cpIcon;
-    protected $cpSection;
-    protected $cpTitle;
     protected $hidden;
     protected $route;
     protected $template;
@@ -99,32 +97,6 @@ class Resource
             ->getter(function ($value) {
                 if (! $value) {
                     return file_get_contents(__DIR__ . '/../resources/svg/database.svg');
-                }
-
-                return $value;
-            })
-            ->args(func_get_args());
-    }
-
-    public function cpSection($cpSection = null)
-    {
-        return $this->fluentlyGetOrSet('cpSection')
-            ->getter(function ($value) {
-                if (! $value) {
-                    return __('Content');
-                }
-
-                return $value;
-            })
-            ->args(func_get_args());
-    }
-
-    public function cpTitle($cpTitle = null)
-    {
-        return $this->fluentlyGetOrSet('cpTitle')
-            ->getter(function ($value) {
-                if (! $value) {
-                    return $this->name();
                 }
 
                 return $value;

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -38,18 +38,8 @@ class Runway
                     $resource->blueprint($config['blueprint']);
                 }
 
-                if (isset($config['nav']['icon'])) {
-                    $resource->cpIcon($config['nav']['icon']);
-                } elseif (isset($config['listing']['cp_icon'])) {
-                    $resource->cpIcon($config['listing']['cp_icon']);
-                }
-
-                if (isset($config['nav']['section'])) {
-                    $resource->cpSection($config['nav']['section']);
-                }
-
-                if (isset($config['nav']['title'])) {
-                    $resource->cpTitle($config['nav']['title']);
+                if (isset($config['cp_icon'])) {
+                    $resource->cpIcon($config['cp_icon']);
                 }
 
                 if (isset($config['hidden'])) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -95,8 +95,8 @@ class ServiceProvider extends AddonServiceProvider
                     continue;
                 }
 
-                $nav->content($resource->cpTitle())
-                    ->section($resource->cpSection())
+                $nav->content($resource->name())
+                    ->section(__('Content'))
                     ->icon($resource->cpIcon())
                     ->route('runway.index', ['resourceHandle' => $resource->handle()])
                     ->can("View {$resource->plural()}");


### PR DESCRIPTION
This pull request drops the configuration options for Control Panel navigation. 

The section & title of items in the Control Panel Nav can now be easily edited by the new 'CP Nav' preferences section added in statamic/cms#6678.

I've left the icon config option however, as that's not configurable within the new Nav Preferences. However, I've renamed it so you will need to adjust your config:

### Before

```php
'resources' => [
    \App\Models\Order::class => [
        'name' => 'Orders',
        'nav' => [
            'icon' => 'date',
        ],
    ],
],
```

### After

```php
'resources' => [
    \App\Models\Order::class => [
        'name' => 'Orders',
        'cp_icon' => 'date',
    ],
],
```