### PR TITLE
2.x: Fix relationship stacks opening empty

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -32,6 +32,7 @@ class BaseFieldtype extends Relationship
         'method' => 'method',
         'resourceHasRoutes' => 'resourceHasRoutes',
         'permalink' => 'permalink',
+        'resource' => 'resource',
     ];
 
     protected function configFieldItems(): array

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -63,7 +63,9 @@ class ResourceController extends CpController
                     ]),
                 ],
             ]),
-            'resource' => $resource,
+            'resource' => $request->wantsJson()
+                ? $resource->toArray()
+                : $resource,
             'blueprint' => $blueprint->toPublishArray(),
             'values' => $fields->values(),
             'meta' => $fields->meta(),


### PR DESCRIPTION
This pull request fixes an issue where the stacks for relationship fieldtypes were empty upon opening up. There were also a few errors in the console.

This issue was caused by #198 where we added a new required prop (`resource`). This prop was being passed to the 'base' publish forms but not to the publish form when it opened in a stack inside a relationship fieldtype.

This PR fixes that.

Fixes #207