### PR TITLE
feat: Make permission keys configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### What's new
+
+* You may now translate permission names #214 by @MtDalPizzol
+
+### Breaking changes
+
+* Permission keys have changed. If you have a user role with custom permissions set, you may need to make some changes:
+    * **File driver:** If you're using the file users repository, your `roles.yaml` file will have been updated automatically with the new permission names.
+    * **Otherwise:** You'll need to change permission names yourself - examples of the changes are shown below.
+        * `View Products` -> `view product`
+        * `Edit Products` -> `edit product`
+        * `Create new Product` -> `create product`
+        * `Delete Product` -> `delete product`
+
 ## v3.0.2 (2023-01-28)
 
 ### What's fixed

--- a/docs/control-panel.md
+++ b/docs/control-panel.md
@@ -46,46 +46,46 @@ You can either provide the name of an existing icon [packaged into Statamic Core
 
 ![Screenshot of Runway's User Permissions](/img/runway/cp-user-permissions.png)
 
-If you have other users who are not ‘super users’, you may wish to also give them permission to view/create/update specific resources.
+If you have other users who are not 'super users', you may wish to also give them permission to view/create/update specific resources.
 
 Runway gives you granular control over which actions users can/cannot do for each of your resources.
 
 ### Permission labels
 
-You can customize permission labels by adding a `resources/lang/{lang}/runway.php` file.
+You may customize permission labels by adding a `resources/lang/{lang}/runway.php` file.
 
 ```php
-  // resources/lang/pt_BR/runway.php
+// resources/lang/pt_BR/runway.php
 
-  'permissions' => [
-      'create' => 'Criar :resource',
-      'delete' => 'Excluir :resource',
-      'edit' => 'Editar :resource',
-      'view' => 'Visualizar :resource'
-  ]
+'permissions' => [
+    'create' => 'Criar :resource',
+    'delete' => 'Excluir :resource',
+    'edit' => 'Editar :resource',
+    'view' => 'Visualizar :resource'
+]
 ```
 
 In the example above, `:resource` will be replaced by the resource's `name`.
 
 ### Custom permissions
 
-You can also add new permissions to the existing Runway default ones.
+If you need to, you can add new permissions to the existing ones created by Runway:
 
 ```php
 // app/Providers/AppServiceProvider.php
 
 public function boot()
 {
-  Permission::group('Runway', function () {
-    foreach (Runway::allResources() as $resource) {
-        Permission::get("edit {$resource->handle()}")->addChild(
-            Permission::make("edit other owners {$resource->handle()}")
-                ->label(trans('runway.permissions.edit_other_owners_resource', [
-                    'resource' => $resource->name()
-                ]))
-        );
-    }
-  });
+    Permission::group('Runway', function () {
+        foreach (Runway::allResources() as $resource) {
+            Permission::get("edit {$resource->handle()}")->addChild(
+                Permission::make("edit other owners {$resource->handle()}")
+                    ->label(trans('runway.permissions.edit_other_owners_resource', [
+                        'resource' => $resource->name()
+                    ]))
+            );
+        }
+    });
 }
 ```
 

--- a/docs/control-panel.md
+++ b/docs/control-panel.md
@@ -1,5 +1,5 @@
 ---
-title: "Control Panel"
+title: 'Control Panel'
 ---
 
 One of Runway’s core features is the Control Panel integration. Runway will create listing and publish form pages for each of your resources.
@@ -49,6 +49,64 @@ You can either provide the name of an existing icon [packaged into Statamic Core
 If you have other users who are not ‘super users’, you may wish to also give them permission to view_create_update specific resources.
 
 Runway gives you granular control over which actions users can/cannot do for each of your resources.
+
+### Permission keys
+
+By default, Runway generates permission keys using English and the automatic pluralized and singularized forms of the resource name. For instance: a resource named "Posts" will generate permission keys like `View Posts` and `Create new Post`. This might not be the best fit for you and you can learn more [here](https://github.com/duncanmcclean/runway/discussions/211).
+
+You can overcome this replacing the permission key pattern via configuration. This can be whatever you want, but following a more "Statamic like" pattern seems to be a good idea.
+
+```php
+  // config/runway.php
+
+  'permission_keys' => [
+    'create' => 'create {resource}',
+    'delete' => 'delete {resource}',
+    'edit' => 'edit {resource}',
+    'view' => 'view {resource}'
+  ]
+```
+
+In the example above `{resource}` will be replaced by the resource's `handle`, generating keys like `view post` and `create post`.
+
+### Permission labels
+
+If you don't want to show the permissions keys in the control panel, and want to show a more readable text or the translated text for the permission, you can simply add a `resources/lang/{lang}/runway.php` file and set the permission label there.
+
+```php
+  // resources/lang/pt_BR/runway.php
+
+  'permissions' => [
+      'create' => 'Criar :resource',
+      'delete' => 'Excluir :resource',
+      'edit' => 'Editar :resource',
+      'view' => 'Visualizar :resource'
+  ]
+```
+
+In the example above, `:resource` will be replaced by the resource's `name`, generating labels like `Visualizar Posts` e `Criar Posts`.
+
+### Custom permissions
+
+You can also add new permissions to the existing Runway default ones.
+
+```php
+// app/Providers/AppServiceProvider.php
+
+public function boot()
+{
+  Permission::group('Runway', function () {
+    foreach (Runway::allResources() as $resource) {
+        Permission::get("edit {$resource->handle()}")->addChild(
+            Permission::make("edit other owners {$resource->handle()}")
+                ->label(trans('runway.permissions.edit_other_owners_resource', [
+                    'resource' => $resource->name()
+                ]))
+        );
+    }
+  });
+}
+```
 
 ## Actions
 

--- a/docs/control-panel.md
+++ b/docs/control-panel.md
@@ -50,28 +50,9 @@ If you have other users who are not ‘super users’, you may wish to also give
 
 Runway gives you granular control over which actions users can/cannot do for each of your resources.
 
-### Permission keys
-
-By default, Runway generates permission keys using English and the automatic pluralized and singularized forms of the resource name. For instance: a resource named "Posts" will generate permission keys like `View Posts` and `Create new Post`. This might not be the best fit for you and you can learn more [here](https://github.com/duncanmcclean/runway/discussions/211).
-
-You can overcome this replacing the permission key pattern via configuration. This can be whatever you want, but following a more "Statamic like" pattern seems to be a good idea.
-
-```php
-  // config/runway.php
-
-  'permission_keys' => [
-    'create' => 'create {resource}',
-    'delete' => 'delete {resource}',
-    'edit' => 'edit {resource}',
-    'view' => 'view {resource}'
-  ]
-```
-
-In the example above `{resource}` will be replaced by the resource's `handle`, generating keys like `view post` and `create post`.
-
 ### Permission labels
 
-If you don't want to show the permissions keys in the control panel, and want to show a more readable text or the translated text for the permission, you can simply add a `resources/lang/{lang}/runway.php` file and set the permission label there.
+You can customize permission labels by adding a `resources/lang/{lang}/runway.php` file.
 
 ```php
   // resources/lang/pt_BR/runway.php
@@ -84,7 +65,7 @@ If you don't want to show the permissions keys in the control panel, and want to
   ]
 ```
 
-In the example above, `:resource` will be replaced by the resource's `name`, generating labels like `Visualizar Posts` e `Criar Posts`.
+In the example above, `:resource` will be replaced by the resource's `name`.
 
 ### Custom permissions
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "scripts": {
+        "build": "NODE_OPTIONS='--openssl-legacy-provider' npm run production",
         "dev": "npm run development",
         "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "watch": "npm run development -- --watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
     "scripts": {
-        "build": "NODE_OPTIONS='--openssl-legacy-provider' npm run production",
         "dev": "npm run development",
         "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
         "watch": "npm run development -- --watch",

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -7,7 +7,7 @@
         <h1 class="flex-1">{{ $title }}</h1>
 
         @if(! $resource->readOnly())
-            @can('Create new ' . $resource->singular())
+            @can('create ' . $resource->handle())
                 <a
                     class="btn-primary"
                     href="{{ cp_route('runway.create', ['resourceHandle' => $resource->handle()]) }}"

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -7,7 +7,7 @@
         <h1 class="flex-1">{{ $title }}</h1>
 
         @if(! $resource->readOnly())
-            @can('create ' . $resource->handle())
+            @can("create {$resource->handle()}")
                 <a
                     class="btn-primary"
                     href="{{ cp_route('runway.create', ['resourceHandle' => $resource->handle()]) }}"

--- a/src/Actions/DeleteModel.php
+++ b/src/Actions/DeleteModel.php
@@ -35,7 +35,7 @@ class DeleteModel extends Action
     {
         $resource = Runway::findResourceByModel($item);
 
-        return $user->hasPermission("Delete {$resource->singular()}")
+        return $user->hasPermission("delete {$resource->handle()}")
             || $user->isSuper();
     }
 

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -274,8 +274,8 @@ class BaseFieldtype extends Relationship
                     'id' => $record->{$resource->primaryKey()},
                     'title' => $this->makeTitle($record, $resource),
                     'edit_url' => $editUrl,
-                    'editable' => User::current()->hasPermission("Edit {$resource->plural()}") || User::current()->isSuper(),
-                    'viewable' => User::current()->hasPermission("View {$resource->plural()}") || User::current()->isSuper(),
+                    'editable' => User::current()->hasPermission("edit {$resource->handle()}") || User::current()->isSuper(),
+                    'viewable' => User::current()->hasPermission("view {$resource->handle()}") || User::current()->isSuper(),
                     'actions' => Action::for($record, ['resource' => $resource->handle()])->reject(fn ($action) => $action instanceof DeleteModel)->toArray(),
                 ])
                 ->toArray();

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -18,7 +18,7 @@ class ResourceListingController extends CpController
         $resource = Runway::findResource($resourceHandle);
         $blueprint = $resource->blueprint();
 
-        if (! User::current()->hasPermission("View {$resource->plural()}") && ! User::current()->isSuper()) {
+        if (! User::current()->hasPermission("view {$resource->handle()}") && ! User::current()->isSuper()) {
             abort(403);
         }
 

--- a/src/Http/Requests/CreateRequest.php
+++ b/src/Http/Requests/CreateRequest.php
@@ -16,7 +16,7 @@ class CreateRequest extends FormRequest
             return false;
         }
 
-        return User::current()->hasPermission("Create new {$resource->singular()}")
+        return User::current()->hasPermission("create {$resource->handle()}")
             || User::current()->isSuper();
     }
 

--- a/src/Http/Requests/EditRequest.php
+++ b/src/Http/Requests/EditRequest.php
@@ -12,7 +12,7 @@ class EditRequest extends FormRequest
     {
         $resource = Runway::findResource($this->resourceHandle);
 
-        return User::current()->hasPermission("Edit {$resource->plural()}")
+        return User::current()->hasPermission("edit {$resource->handle()}")
             || User::current()->isSuper();
     }
 

--- a/src/Http/Requests/IndexRequest.php
+++ b/src/Http/Requests/IndexRequest.php
@@ -12,7 +12,7 @@ class IndexRequest extends FormRequest
     {
         $resource = Runway::findResource($this->resourceHandle);
 
-        return User::current()->hasPermission("View {$resource->plural()}")
+        return User::current()->hasPermission("view {$resource->handle()}")
             || User::current()->isSuper();
     }
 

--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -16,7 +16,7 @@ class StoreRequest extends FormRequest
             return false;
         }
 
-        return User::current()->hasPermission("Create new {$resource->singular()}")
+        return User::current()->hasPermission("create {$resource->handle()}")
             || User::current()->isSuper();
     }
 

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -16,7 +16,7 @@ class UpdateRequest extends FormRequest
             return false;
         }
 
-        return User::current()->hasPermission("Edit {$resource->plural()}")
+        return User::current()->hasPermission("edit {$resource->handle()}")
             || User::current()->isSuper();
     }
 

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -91,8 +91,8 @@ class ResourceCollection extends LaravelResourceCollection
                 $row['id'] = $record->getKey();
                 $row['edit_url'] = cp_route('runway.edit', ['resourceHandle' => $handle, 'record' => $record->getRouteKey()]);
                 $row['permalink'] = $this->runwayResource->hasRouting() ? $record->uri() : null;
-                $row['editable'] = User::current()->hasPermission("Edit {$this->runwayResource->plural()}") || User::current()->isSuper();
-                $row['viewable'] = User::current()->hasPermission("View {$this->runwayResource->plural()}") || User::current()->isSuper();
+                $row['editable'] = User::current()->hasPermission("edit {$this->runwayResource->handle()}") || User::current()->isSuper();
+                $row['viewable'] = User::current()->hasPermission("view {$this->runwayResource->handle()}") || User::current()->isSuper();
                 $row['actions'] = Action::for($record, ['resource' => $this->runwayResource->handle()]);
 
                 return $row;

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -67,6 +67,7 @@ class ServiceProvider extends AddonServiceProvider
             $this->registerPermissions();
             $this->registerNavigation();
             $this->bootGraphQl();
+
             SearchProvider::register();
             $this->bootModelEventListeners();
 
@@ -75,26 +76,6 @@ class ServiceProvider extends AddonServiceProvider
                     ->setRepository('runway-resources', Routing\ResourceRoutingRepository::class);
             }
         });
-    }
-
-    protected function permissionLabel($permission, $resource)
-    {
-        $translationKey = "runway.permissions.{$permission}";
-
-        $label = trans($translationKey, [
-            'resource' => $resource->name(),
-        ]);
-
-        if ($label == $translationKey) {
-            return match ($permission) {
-                'view' => "View {$resource->name()}",
-                'edit' => "Edit {$resource->name()}",
-                'create' => "Create {$resource->name()}",
-                'delete' => "Delete {$resource->name()}"
-            };
-        }
-
-        return $label;
     }
 
     protected function registerPermissions()
@@ -109,6 +90,7 @@ class ServiceProvider extends AddonServiceProvider
                             ->children([
                                 Permission::make("create {$resource->handle()}")
                                     ->label($this->permissionLabel('create', $resource)),
+
                                 Permission::make("delete {$resource->handle()}")
                                     ->label($this->permissionLabel('delete', $resource)),
                             ]),
@@ -162,5 +144,25 @@ class ServiceProvider extends AddonServiceProvider
                 Event::listen('eloquent.saved: ' . $class, fn ($model) => Search::updateWithinIndexes(new Searchable($model)));
                 Event::listen('eloquent.deleted: ' . $class, fn ($model) => Search::deleteFromIndexes(new Searchable($model)));
             });
+    }
+
+    protected function permissionLabel($permission, $resource)
+    {
+        $translationKey = "runway.permissions.{$permission}";
+
+        $label = trans($translationKey, [
+            'resource' => $resource->name(),
+        ]);
+
+        if ($label == $translationKey) {
+            return match ($permission) {
+                'view' => "View {$resource->name()}",
+                'edit' => "Edit {$resource->name()}",
+                'create' => "Create {$resource->name()}",
+                'delete' => "Delete {$resource->name()}"
+            };
+        }
+
+        return $label;
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -42,6 +42,10 @@ class ServiceProvider extends AddonServiceProvider
         Tags\RunwayTag::class,
     ];
 
+    protected $updateScripts = [
+        UpdateScripts\ChangePermissionNames::class,
+    ];
+
     public function boot()
     {
         parent::boot();

--- a/src/UpdateScripts/ChangePermissionNames.php
+++ b/src/UpdateScripts/ChangePermissionNames.php
@@ -36,7 +36,7 @@ class ChangePermissionNames extends UpdateScript
                                 ->replace("View {$resource->plural()}", "view {$resource->handle()}")
                                 ->replace("Edit {$resource->plural()}", "edit {$resource->handle()}")
                                 ->replace("Create new {$resource->singular()}", "create {$resource->handle()}")
-                                ->replace("Delete {$resource->plural()}", "delete {$resource->handle()}")
+                                ->replace("Delete {$resource->singular()}", "delete {$resource->handle()}")
                                 ->__toString();
                         });
 

--- a/src/UpdateScripts/ChangePermissionNames.php
+++ b/src/UpdateScripts/ChangePermissionNames.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\UpdateScripts;
+
+use DoubleThreeDigital\Runway\Resource;
+use DoubleThreeDigital\Runway\Runway;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Statamic\Facades\Yaml;
+use Statamic\UpdateScripts\UpdateScript;
+
+class ChangePermissionNames extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('4.0.0');
+    }
+
+    public function update()
+    {
+        if (config('statamic.users.repository') !== 'file') {
+            $this->console()->warn("Runway has made updates to it's permissions. You'll need to update your user permissions manually.");
+            $this->console()->warn('Please see the upgrade guide for more information: TODO');
+
+            return;
+        }
+
+        $roles = Yaml::file(config('statamic.users.repositories.file.paths.roles'))->parse();
+
+        $roles = collect($roles)
+            ->map(function ($role) {
+                $role['permissions'] = collect($role['permissions'] ?? [])
+                    ->map(function ($permission) {
+                        Runway::allResources()->each(function (Resource $resource) use (&$permission) {
+                            $permission = Str::of($permission)
+                                ->replace("View {$resource->plural()}", "view {$resource->handle()}")
+                                ->replace("Edit {$resource->plural()}", "edit {$resource->handle()}")
+                                ->replace("Create new {$resource->singular()}", "create {$resource->handle()}")
+                                ->replace("Delete {$resource->plural()}", "delete {$resource->handle()}")
+                                ->__toString();
+                        });
+
+                        return $permission;
+                    })
+                    ->values()
+                    ->toArray();
+
+                return $role;
+            })
+            ->toArray();
+
+        $yaml = Yaml::dump($roles);
+
+        File::put(config('statamic.users.repositories.file.paths.roles'), $yaml);
+    }
+}

--- a/tests/Helpers/RunsUpdateScripts.php
+++ b/tests/Helpers/RunsUpdateScripts.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests\Helpers;
+
+trait RunsUpdateScripts
+{
+    /**
+     * Run update script in your tests without checking package version.
+     *
+     * @param  string  $fqcn
+     * @param  string  $package
+     */
+    protected function runUpdateScript($fqcn, $package = 'doublethreedigital/runway')
+    {
+        $script = new $fqcn($package);
+
+        $script->update();
+    }
+}

--- a/tests/UpdateScripts/ChangePermissionNamesTest.php
+++ b/tests/UpdateScripts/ChangePermissionNamesTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests\UpdateScripts;
+
+use DoubleThreeDigital\Runway\Tests\Helpers\RunsUpdateScripts;
+use DoubleThreeDigital\Runway\Tests\TestCase;
+use DoubleThreeDigital\Runway\UpdateScripts\ChangePermissionNames;
+use Illuminate\Support\Facades\File;
+
+class ChangePermissionNamesTest extends TestCase
+{
+    use RunsUpdateScripts;
+
+    /** @test */
+    public function it_can_change_permission_names()
+    {
+        File::ensureDirectoryExists(resource_path('users'));
+
+        File::put(
+            config('statamic.users.repositories.file.paths.roles'),
+            File::get(__DIR__.'/../__fixtures__/resources/users/roles.yaml')
+        );
+
+        $this->runUpdateScript(ChangePermissionNames::class);
+
+        $roles = File::get(config('statamic.users.repositories.file.paths.roles'));
+
+        $this->assertStringContainsString('view post', $roles);
+        $this->assertStringNotContainsString('View Posts', $roles);
+
+        $this->assertStringContainsString('edit post', $roles);
+        $this->assertStringNotContainsString('Edit Posts', $roles);
+
+        $this->assertStringContainsString('create post', $roles);
+        $this->assertStringNotContainsString('Create new Post', $roles);
+
+        $this->assertStringContainsString('delete post', $roles);
+        $this->assertStringNotContainsString('Delete Post', $roles);
+    }
+}

--- a/tests/__fixtures__/resources/users/roles.yaml
+++ b/tests/__fixtures__/resources/users/roles.yaml
@@ -1,0 +1,7 @@
+site_editor:
+  title: Site Editor
+  permissions:
+    - 'View Posts'
+    - 'Edit Posts'
+    - 'Create new Post'
+    - 'Delete Post'


### PR DESCRIPTION
This PR tackles what was discussed [here](https://github.com/duncanmcclean/runway/discussions/211#discussion-4810850) 

- Add ability to override default permission keys
- Add ability to customize permission labels
- Add detailed docs on how to override permission keys, localize labels and add custom permissions
- Add a "build" script to package.json to allow building on newer Node.js versions