### PR TITLE
Fix `sort` parameter in Runway tag

### DIFF
--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -57,7 +57,7 @@ class RunwayTag extends Tags
             $query->with(explode('|', (string) $with));
         }
 
-        if ($this->params->has('sort')) {
+        if ($this->params->has('sort') && ! empty($this->params->get('sort'))) {
             $sortColumn = explode(':', (string) $this->params->get('sort'))[0];
             $sortDirection = explode(':', (string) $this->params->get('sort'))[1];
 

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -58,8 +58,13 @@ class RunwayTag extends Tags
         }
 
         if ($this->params->has('sort') && ! empty($this->params->get('sort'))) {
-            $sortColumn = explode(':', (string) $this->params->get('sort'))[0];
-            $sortDirection = explode(':', (string) $this->params->get('sort'))[1];
+            if (Str::contains($this->params->get('sort'), ':')) {
+                $sortColumn = explode(':', (string) $this->params->get('sort'))[0];
+                $sortDirection = explode(':', (string) $this->params->get('sort'))[1];
+            } else {
+                $sortColumn = $this->params->get('sort');
+                $sortDirection = 'asc';
+            }
 
             $query->orderBy($sortColumn, $sortDirection);
         }


### PR DESCRIPTION
This pull request fixes two issues I spotted earlier today in the Runway tag:

1. If the value passed to the `sort` parameter is `null` (for example: if it's based on a query parameter but it's not present), then previously you'd receive an error. Now any sorting will just be ignored when that's the case.
2. You couldn't *just* provide the column you wanted to sort with, you also had to specify the sort direction you wanted too. Now, you don't have to. If no direction is provided, results will be sorted in `asc` order.

Closes #213