### PR TITLE
Prevent resource row selection

### DIFF
--- a/resources/js/components/Listing/ListingView.vue
+++ b/resources/js/components/Listing/ListingView.vue
@@ -71,7 +71,7 @@
                             :slot="primaryColumn"
                             slot-scope="{ row, value }"
                         >
-                            <a :href="row.edit_url">{{ value }}</a>
+                            <a :href="row.edit_url" @click.stop>{{ value }}</a>
                         </template>
 
                         <template slot="actions" slot-scope="{ row, index }">


### PR DESCRIPTION
When clicking the edit link inside a row in a resource listing, before the editing page is loaded, the row gets briefly selected as if the user has clicked the row, not the link.

This will stop the click propagation from the link and prevent the selection from happening.

Originally #219 but I've cherry-picked the commit to avoid pulling over unrelated changes. 