### PR TITLE
Exclude sections and computed values from search

### DIFF
--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -51,7 +51,9 @@ class ResourceListingController extends CpController
                     $blueprint->fields()->items()
                         ->reject(function (array $field) {
                             return $field['field']['type'] === 'has_many'
-                                || $field['field']['type'] === 'hidden';
+                                || $field['field']['type'] === 'hidden'
+                                || $field['field']['type'] === 'section'
+                                || (isset($field['field']['visibility']) && $field['field']['visibility'] === 'computed');
                         })
                         ->each(function (array $field) use ($query, $searchQuery) {
                             $query->orWhere($field['handle'], 'LIKE', '%' . $searchQuery . '%');


### PR DESCRIPTION
Stumbled across this today: when trying to search in a simple commerce resource (orders) I kept hitting SQL errors because section fields as well as computed fields were included and the app couldn't find columns for those in the database.