### PR TITLE
Support relationships in `where` parameter on Runway tag

### DIFF
--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -5,6 +5,7 @@ namespace DoubleThreeDigital\Runway\Tags;
 use DoubleThreeDigital\Runway\Exceptions\ResourceNotFound;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Tags\Tags;
@@ -51,7 +52,22 @@ class RunwayTag extends Tags
         }
 
         if ($this->params->has('where') && $where = $this->params->get('where')) {
-            $query->where(explode(':', (string) $where)[0], explode(':', (string) $where)[1]);
+            $key = explode(':', (string) $where)[0];
+            $value = explode(':', (string) $where)[1];
+
+            if ($resource->eagerLoadingRelations()->has($key)) {
+                // eagerLoadingRelations() return a Collection of keys/values, the keys are the field names 
+                // & the values are the Eloquent relationship names. We need to get the relationship name 
+                // for the whereHas query.
+                $relationshipName = $resource->eagerLoadingRelations()->get($key);
+                $relationshipResource = Runway::findResource($resource->blueprint()->field($key)->config()['resource']);
+
+                $query->whereHas($relationshipName, function ($query) use ($key, $value, $relationshipResource) {
+                    $query->whereIn($relationshipResource->databaseTable() . '.' . $relationshipResource->primaryKey(), Arr::wrap($value));
+                });
+            } else {
+                $query->where($key, $value);
+            }
         }
 
         if ($with = $this->params->get('with')) {

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -56,13 +56,13 @@ class RunwayTag extends Tags
             $value = explode(':', (string) $where)[1];
 
             if ($resource->eagerLoadingRelations()->has($key)) {
-                // eagerLoadingRelations() return a Collection of keys/values, the keys are the field names 
-                // & the values are the Eloquent relationship names. We need to get the relationship name 
+                // eagerLoadingRelations() return a Collection of keys/values, the keys are the field names
+                // & the values are the Eloquent relationship names. We need to get the relationship name
                 // for the whereHas query.
                 $relationshipName = $resource->eagerLoadingRelations()->get($key);
                 $relationshipResource = Runway::findResource($resource->blueprint()->field($key)->config()['resource']);
 
-                $query->whereHas($relationshipName, function ($query) use ($key, $value, $relationshipResource) {
+                $query->whereHas($relationshipName, function ($query) use ($value, $relationshipResource) {
                     $query->whereIn($relationshipResource->databaseTable() . '.' . $relationshipResource->primaryKey(), Arr::wrap($value));
                 });
             } else {

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -130,6 +130,28 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
+    public function can_get_records_with_where_parameter_when_condition_is_on_relationship_field()
+    {
+        $posts = $this->postFactory(5);
+        $author = $this->authorFactory();
+
+        $posts[0]->update(['author_id' => $author->id]);
+        $posts[2]->update(['author_id' => $author->id]);
+        $posts[3]->update(['author_id' => $author->id]);
+
+        $this->tag->setParameters([
+            'where' => 'author_id:' . $author->id,
+        ]);
+
+        $usage = $this->tag->wildcard('post');
+
+        $this->assertSame(3, count($usage));
+        $this->assertSame((string) $usage[0]['title'], $posts[0]->title);
+        $this->assertSame((string) $usage[1]['title'], $posts[2]->title);
+        $this->assertSame((string) $usage[2]['title'], $posts[3]->title);
+    }
+
+    /** @test */
     public function can_get_records_with_with_parameter()
     {
         $posts = $this->postFactory(5);


### PR DESCRIPTION
This pull request adds the ability for you to query Eloquent relationships using the `where` parameter on the Runway tag.

## Example

```antlers
{{ runway:course as="courses" where="topics:{ get:topics }" }}
  <!-- Courses with the selected topic -->
{{ /runway:course }}
```

In this case, `get:topics` is the ID of a topic model. 