### PR TITLE
Switch to Vite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,6 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           tools: composer:v2
 
-      - name: Use Node.js 16.13.0
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16.13.0
-
       - name: Install NPM Dependencies
         run: npm install
 
@@ -39,10 +34,10 @@ jobs:
         run: composer install
 
       - name: Compile assets
-        run: npm run production
+        run: npm run build
 
       - name: Create zip
-        run: cd resources && tar -czvf dist.tar.gz dist
+        run: tar -czvf dist.tar.gz dist
 
       - name: Get Changelog
         id: changelog
@@ -67,7 +62,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./resources/dist.tar.gz
+          asset_path: ./dist.tar.gz
           asset_name: dist.tar.gz
           asset_content_type: application/tar+gz
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,15 @@
-vendor
 .DS_Store
 .phpunit.result.cache
+.php_cs.cache
+.php-cs-fixer.cache
+.idea
+vendor
 node_modules
 package-lock.json
-.php_cs.cache
-.idea
 tests/__fixtures__/users/.yaml
 composer.lock
 
-resources/dist/js/*.js
-resources/dist/mix-manifest.json
-.php-cs-fixer.cache
+dist
+!dist/.gitkeep
+vite.hot
+.env

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         },
         "download-dist": {
             "url": "https://github.com/duncanmcclean/runway/releases/download/{$version}/dist.tar.gz",
-            "path": "resources/dist"
+            "path": "dist"
         }
     },
     "require": {

--- a/package.json
+++ b/package.json
@@ -1,23 +1,19 @@
 {
     "scripts": {
-        "dev": "npm run development",
-        "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "npm run development -- --watch",
-        "watch-poll": "npm run watch -- --watch-poll",
-        "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "prod": "npm run production",
-        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "dev": "vite",
+        "build": "vite build"
     },
     "dependencies": {
         "@shopify/draggable": "^1.0.0-beta.8",
         "axios": "^0.21.1",
         "cross-env": "^7.0.2",
-        "laravel-mix": "^5.0.4",
         "qs": "^6.11.0",
         "uniqid": "^5.2.0",
         "vue": "^2.6.11"
     },
     "devDependencies": {
-        "vue-template-compiler": "^2.6.11"
+        "@vitejs/plugin-vue2": "^2.2.0",
+        "laravel-vite-plugin": "^0.7.4",
+        "vite": "^4.1.4"
     }
 }

--- a/resources/js/components/Fieldtypes/Relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/Fieldtypes/Relationship/RelationshipFieldtype.vue
@@ -34,7 +34,6 @@
 
 <script>
 // Note: this file has been copied from Statamic almost completely APART from the 'componentName' computed property which we've added.
-
 import qs from 'qs'
 
 export default {

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -95,8 +95,8 @@
 </template>
 
 <script>
-import SaveButtonOptions from '../statamic/SaveButtonOptions'
-import HasPreferences from '../statamic/HasPreferences'
+import SaveButtonOptions from '../statamic/SaveButtonOptions.vue'
+import HasPreferences from '../statamic/HasPreferences.js'
 
 export default {
     components: {

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,6 +1,6 @@
-import RelationshipFieldtype from './components/Fieldtypes/Relationship/RelationshipFieldtype'
-import RelationshipTableMode from './components/Fieldtypes/Relationship/RelationshipTableMode'
-import HasManyRelatedItem from './components/Fieldtypes/HasManyRelatedItem'
+import RelationshipFieldtype from './components/Fieldtypes/Relationship/RelationshipFieldtype.vue'
+import RelationshipTableMode from './components/Fieldtypes/Relationship/RelationshipTableMode.vue'
+import HasManyRelatedItem from './components/Fieldtypes/HasManyRelatedItem.vue'
 import PublishForm from './components/Publish/PublishForm.vue'
 import ListingView from './components/Listing/ListingView.vue'
 
@@ -17,3 +17,5 @@ Statamic.$components.register('runway-listing-view', ListingView)
 import HasManyFieldtypeIndex from '../../vendor/statamic/cms/resources/js/components/fieldtypes/relationship/RelationshipIndexFieldtype.vue'
 
 Statamic.$components.register('has_many-fieldtype-index', HasManyFieldtypeIndex)
+
+console.log('fresh code dude')

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -36,16 +36,16 @@ class ServiceProvider extends AddonServiceProvider
         'cp' => __DIR__.'/../routes/cp.php',
     ];
 
-    protected $scripts = [
-        __DIR__.'/../resources/dist/js/cp.js',
-    ];
-
     protected $tags = [
         Tags\RunwayTag::class,
     ];
 
     protected $updateScripts = [
         UpdateScripts\ChangePermissionNames::class,
+    ];
+
+    protected $vite = [
+        'resources/js/cp.js',
     ];
 
     public function boot()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,6 +29,8 @@ abstract class TestCase extends OrchestraTestCase
         $this->runLaravelMigrations();
         $this->loadMigrationsFrom(__DIR__.'/__fixtures__/database/migrations');
 
+        $this->withoutVite();
+
         if ($this->shouldFakeVersion) {
             \Facades\Statamic\Version::shouldReceive('get')->andReturn('3.1.0-testing');
             $this->addToAssertionCount(-1); // Dont want to assert this

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vite'
+import laravel from 'laravel-vite-plugin'
+import vue2 from '@vitejs/plugin-vue2'
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            hotFile: 'vite.hot',
+            publicDirectory: 'dist',
+            input: ['resources/js/cp.js'],
+        }),
+        vue2(),
+    ],
+})

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,4 +1,0 @@
-let mix = require('laravel-mix');
-
-mix.js('resources/js/cp.js', 'resources/dist/js/cp.js')
-    .setPublicPath('resources/dist');


### PR DESCRIPTION
This pull request switches the front-end build tool from Laravel Mix to Vite for speedy build times. ✨

It also means that whenever you're working with Runway locally, you'll no longer need to symlink the `resources/dist` folder when running `npm run dev`.

This was made possible by https://github.com/statamic/cms/pull/6869.