### PR TITLE
Various fixes to Has Many Table Mode

### DIFF
--- a/resources/js/components/Fieldtypes/Relationship/RelationshipTableMode.vue
+++ b/resources/js/components/Fieldtypes/Relationship/RelationshipTableMode.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="relationship-input overflow-x-scroll max-w-full"
+        class="relationship-input"
         :class="{ 'relationship-input-empty': items.length == 0 }"
     >
         <loading-graphic v-if="initializing" :inline="true" />
@@ -69,7 +69,7 @@
                                     class="divider"
                                     v-if="
                                         (canViewRow(row) || canEditRow(row)) &&
-                                        row.actions.length
+                                            row.actions.length
                                     "
                                 />
 
@@ -248,8 +248,8 @@ export default {
 
     computed: {
         items() {
-            return this.value.map((selection) => {
-                const data = _.find(this.data, (item) => item.id == selection)
+            return this.value.map(selection => {
+                const data = _.find(this.data, item => item.id == selection)
 
                 if (!data) return { id: selection, title: selection }
 
@@ -320,7 +320,7 @@ export default {
 
             this.initializing = true
 
-            let data = this.data.map((item) => {
+            let data = this.data.map(item => {
                 if (item.id == responseData.id) {
                     return {
                         ...item,
@@ -373,7 +373,7 @@ export default {
 
             return this.$axios
                 .post(this.itemDataUrl, { site: this.site, selections })
-                .then((response) => {
+                .then(response => {
                     this.$emit('item-data-updated', response.data.data)
                 })
                 .finally(() => {
@@ -390,13 +390,13 @@ export default {
                 plugins: [Plugins.SwapAnimation],
                 delay: 200,
             })
-                .on('drag:start', (e) => {
+                .on('drag:start', e => {
                     this.value.length === 1 ? e.cancel() : this.$emit('focus')
                 })
-                .on('drag:stop', (e) => {
+                .on('drag:stop', e => {
                     this.$emit('blur')
                 })
-                .on('sortable:stop', (e) => {
+                .on('sortable:stop', e => {
                     const val = [...this.value]
                     val.splice(e.newIndex, 0, val.splice(e.oldIndex, 1)[0])
                     this.update(val)
@@ -411,12 +411,12 @@ export default {
         selectFieldSelected(selectedItemData) {
             this.$emit(
                 'item-data-updated',
-                selectedItemData.map((item) => ({
+                selectedItemData.map(item => ({
                     id: item.id,
                     title: item.title,
                 }))
             )
-            this.update(selectedItemData.map((item) => item.id))
+            this.update(selectedItemData.map(item => item.id))
         },
 
         setLoadingProgress(state) {

--- a/resources/js/components/Fieldtypes/Relationship/RelationshipTableMode.vue
+++ b/resources/js/components/Fieldtypes/Relationship/RelationshipTableMode.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="relationship-input"
+        class="relationship-input overflow-x-scroll max-w-full"
         :class="{ 'relationship-input-empty': items.length == 0 }"
     >
         <loading-graphic v-if="initializing" :inline="true" />
@@ -69,7 +69,7 @@
                                     class="divider"
                                     v-if="
                                         (canViewRow(row) || canEditRow(row)) &&
-                                            row.actions.length
+                                        row.actions.length
                                     "
                                 />
 
@@ -248,8 +248,8 @@ export default {
 
     computed: {
         items() {
-            return this.value.map(selection => {
-                const data = _.find(this.data, item => item.id == selection)
+            return this.value.map((selection) => {
+                const data = _.find(this.data, (item) => item.id == selection)
 
                 if (!data) return { id: selection, title: selection }
 
@@ -320,7 +320,7 @@ export default {
 
             this.initializing = true
 
-            let data = this.data.map(item => {
+            let data = this.data.map((item) => {
                 if (item.id == responseData.id) {
                     return {
                         ...item,
@@ -373,7 +373,7 @@ export default {
 
             return this.$axios
                 .post(this.itemDataUrl, { site: this.site, selections })
-                .then(response => {
+                .then((response) => {
                     this.$emit('item-data-updated', response.data.data)
                 })
                 .finally(() => {
@@ -390,13 +390,13 @@ export default {
                 plugins: [Plugins.SwapAnimation],
                 delay: 200,
             })
-                .on('drag:start', e => {
+                .on('drag:start', (e) => {
                     this.value.length === 1 ? e.cancel() : this.$emit('focus')
                 })
-                .on('drag:stop', e => {
+                .on('drag:stop', (e) => {
                     this.$emit('blur')
                 })
-                .on('sortable:stop', e => {
+                .on('sortable:stop', (e) => {
                     const val = [...this.value]
                     val.splice(e.newIndex, 0, val.splice(e.oldIndex, 1)[0])
                     this.update(val)
@@ -411,12 +411,12 @@ export default {
         selectFieldSelected(selectedItemData) {
             this.$emit(
                 'item-data-updated',
-                selectedItemData.map(item => ({
+                selectedItemData.map((item) => ({
                     id: item.id,
                     title: item.title,
                 }))
             )
-            this.update(selectedItemData.map(item => item.id))
+            this.update(selectedItemData.map((item) => item.id))
         },
 
         setLoadingProgress(state) {

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -233,13 +233,19 @@ class BaseFieldtype extends Relationship
         $blueprint = $resource->blueprint();
 
         return collect($resource->listableColumns())
-            ->map(function ($columnKey) use ($blueprint) {
+            ->map(function ($columnKey, $index) use ($blueprint) {
                 /** @var \Statamic\Fields\Field $field */
                 $blueprintField = $blueprint->field($columnKey);
 
-                return Column::make($columnKey)
-                    ->label($blueprintField->display())
-                    ->fieldtype($blueprintField->fieldtype()->handle());
+                return Column::make()
+                    ->field($blueprintField->handle())
+                    ->label(__($blueprintField->display()))
+                    ->fieldtype($blueprintField->fieldtype()->indexComponent())
+                    ->listable($blueprintField->isListable())
+                    ->defaultVisibility($blueprintField->isVisibleOnListing())
+                    ->visible($blueprintField->isVisibleOnListing())
+                    ->sortable($blueprintField->isSortable())
+                    ->defaultOrder($index + 1);
             })
             ->toArray();
     }

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -277,13 +277,16 @@ class BaseFieldtype extends Relationship
         // When using Table mode, we want to return each item differently.
         if ($this->config('mode') === 'table') {
             return collect($resource->listableColumns())
-                ->mapWithKeys(function ($columnKey) use ($record) {
+                ->mapWithKeys(function ($columnKey) use ($record, $resource) {
                     $value = $record->{$columnKey};
 
                     // When $value is an Eloquent Collection, we want to map over each item & process its values.
                     if ($value instanceof EloquentCollection) {
                         $value = $value->map(fn ($item) => $this->toItemArray($item))->values()->toArray();
                     }
+
+                    // We need to put each column through preProcessIndex so it's formatted properly for the listing table.
+                    $value = $resource->blueprint()->field($columnKey)->setValue($value)->preProcessIndex()->value();
 
                     return [$columnKey => $value];
                 })

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -98,7 +98,8 @@ class Resource
         return $this->blueprint()->fields()->items()
             ->reject(function ($field) {
                 return isset($field['import'])
-                    || (isset($field['field']['listable']) && $field['field']['listable'] === 'hidden');
+                    || (isset($field['field']['listable']) && $field['field']['listable'] === 'hidden')
+                    || (isset($field['field']['listable']) && $field['field']['listable'] === false);
             })
             ->pluck('handle')
             ->toArray();


### PR DESCRIPTION
This pull request fixes various issues I've found when using the Runway's Has Many fieldtype in Table mode:

* Columns set to not be listable (with `listable: false`) were still being shown on the table
* Columns weren't using their relevant 'index components' in the table mode (causing data to display differently when compared to listing tables)
* Data wasn't being run through the `preProcessIndex` on their fieldtypes which they should be before being sent to their 'index components'

I also tried to fix an issue I found around the width of the table going outside the fieldtype container but my CSS skills aren't great - when I tried I broke the drop shadows and the actions dropdown. I'll leave that for another time (or for someone else 😆 )

Closes #243