### PR TITLE
Don't attempt to set data if it's included in the model's `$appends` array

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -95,8 +95,10 @@ class ResourceController extends CpController
                 continue;
             }
 
-            // Skip if this column exists in the model's $appends array.
-            if (in_array($fieldKey, $record->getAppends(), true)) {
+            // Skip if this column exists in the model's $appends array & no column exists for it in the database.
+
+            // Skip if no column exists for it in the database & it's present in the model's $appends array.
+            if (in_array($fieldKey, $record->getAppends(), true) && ! in_array($fieldKey, $resource->databaseColumns(), true)) {
                 continue;
             }
 
@@ -231,8 +233,8 @@ class ResourceController extends CpController
                 continue;
             }
 
-            // Skip if this column exists in the model's $appends array.
-            if (in_array($fieldKey, $record->getAppends(), true)) {
+            // Skip if no column exists for it in the database & it's present in the model's $appends array.
+            if (in_array($fieldKey, $record->getAppends(), true) && ! in_array($fieldKey, $resource->databaseColumns(), true)) {
                 continue;
             }
 

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -95,10 +95,8 @@ class ResourceController extends CpController
                 continue;
             }
 
-            // Skip if this column exists in the model's $appends array & no column exists for it in the database.
-
-            // Skip if no column exists for it in the database & it's present in the model's $appends array.
-            if (in_array($fieldKey, $record->getAppends(), true) && ! in_array($fieldKey, $resource->databaseColumns(), true)) {
+            // Skip if the field exists in the model's $appends array and there's not a set mutator present for it on the model.
+            if (in_array($fieldKey, $record->getAppends(), true) && ! $record->hasSetMutator($fieldKey) && ! $record->hasAttributeSetMutator($fieldKey)) {
                 continue;
             }
 
@@ -233,8 +231,8 @@ class ResourceController extends CpController
                 continue;
             }
 
-            // Skip if no column exists for it in the database & it's present in the model's $appends array.
-            if (in_array($fieldKey, $record->getAppends(), true) && ! in_array($fieldKey, $resource->databaseColumns(), true)) {
+            // Skip if the field exists in the model's $appends array and there's not a set mutator present for it on the model.
+            if (in_array($fieldKey, $record->getAppends(), true) && ! $record->hasSetMutator($fieldKey) && ! $record->hasAttributeSetMutator($fieldKey)) {
                 continue;
             }
 

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -95,6 +95,11 @@ class ResourceController extends CpController
                 continue;
             }
 
+            // Skip if this column exists in the model's $appends array.
+            if (in_array($fieldKey, $record->getAppends(), true)) {
+                continue;
+            }
+
             // Store the HasMany field's value in the $postCreatedHooks array so we
             // can process it after we've finished creating this model.
             if ($field->type() === 'has_many') {
@@ -223,6 +228,11 @@ class ResourceController extends CpController
 
             // Skip section, HasMany and computed fields as there's nothing to store.
             if ($field->type() === 'section' || $field->type() === 'has_many' || $field->visibility() === 'computed') {
+                continue;
+            }
+
+            // Skip if this column exists in the model's $appends array.
+            if (in_array($fieldKey, $record->getAppends(), true)) {
                 continue;
             }
 

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -414,4 +414,32 @@ class ResourceControllerTest extends TestCase
 
         $this->assertSame($post->title, 'Santa is coming home');
     }
+
+    /**
+     * @test
+     * https://github.com/duncanmcclean/runway/pull/247
+     */
+    public function can_update_resource_and_ensure_appended_attribute_doesnt_attempt_to_get_saved()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $post = $this->postFactory();
+
+        $this->actingAs($user)
+            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+                'title' => 'Santa is coming home',
+                'slug' => 'santa-is-coming-home',
+                'body' => $post->body,
+                'excerpt' => 'This is an excerpt.',
+                'author_id' => [$post->author_id],
+            ])
+            ->assertOk()
+            ->assertJsonStructure([
+                'data',
+            ]);
+
+        $post->refresh();
+
+        $this->assertSame($post->title, 'Santa is coming home');
+    }
 }

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -131,6 +131,34 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
+    /**
+     * @test
+     * https://github.com/duncanmcclean/runway/pull/247
+     */
+    public function can_store_resource_and_ensure_appended_attribute_doesnt_attempt_to_get_saved()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $author = $this->authorFactory();
+
+        $this->actingAs($user)
+            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+                'title' => 'Jingle Bells',
+                'slug' => 'jingle-bells',
+                'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
+                'excerpt' => 'This is an excerpt.',
+                'author_id' => [$author->id],
+            ])
+            ->assertOk()
+            ->assertJsonStructure([
+                'redirect',
+            ]);
+
+        $this->assertDatabaseHas('posts', [
+            'title' => 'Jingle Bells',
+        ]);
+    }
+
     /** @test */
     public function can_edit_resource()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -127,6 +127,13 @@ abstract class TestCase extends OrchestraTestCase
                                         ],
                                     ],
                                     [
+                                        'handle' => 'excerpt',
+                                        'field' => [
+                                            'type' => 'textarea',
+                                            'read_only' => true,
+                                        ],
+                                    ],
+                                    [
                                         'handle' => 'author_id',
                                         'field' => [
                                             'type' => 'belongs_to',
@@ -238,6 +245,10 @@ class Post extends Model
         'title', 'slug', 'body', 'author_id',
     ];
 
+    protected $appends = [
+        'excerpt',
+    ];
+
     public function scopeFood($query)
     {
         $query->whereIn('title', ['Pasta', 'Apple', 'Burger']);
@@ -253,6 +264,11 @@ class Post extends Model
     public function author()
     {
         return $this->belongsTo(Author::class);
+    }
+
+    public function getExcerptAttribute()
+    {
+        return 'This is an excerpt.';
     }
 }
 


### PR DESCRIPTION
This pull request fixes #240, where you'd get an error when trying to save a model when the field exists in the model's `$appends` array but not in the database.

This PR fixes that by checking for the presence for the field in `$appends` and also checks to make sure there's no 'set mutator' created for it.