### PR TITLE
Fix ambiguous table error

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -272,7 +272,7 @@ class ResourceController extends CpController
                     $relationshipName = $resource->eagerLoadingRelations()->get($field->handle()) ?? $field->handle();
 
                     $record->{$field->handle()} = $record->{$relationshipName}()
-                        ->select($relatedResource->databaseTable() . '.' . $relatedResource->primaryKey(), $column)
+                        ->select($relatedResource->databaseTable().'.'.$relatedResource->primaryKey(), $column)
                         ->get()
                         ->each(function ($model) use ($relatedResource, $column) {
                             $model->title = $model->{$column};

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -272,7 +272,7 @@ class ResourceController extends CpController
                     $relationshipName = $resource->eagerLoadingRelations()->get($field->handle()) ?? $field->handle();
 
                     $record->{$field->handle()} = $record->{$relationshipName}()
-                        ->select('id', $column)
+                        ->select($relatedResource->databaseTable() . '.' . $relatedResource->primaryKey(), $column)
                         ->get()
                         ->each(function ($model) use ($relatedResource, $column) {
                             $model->title = $model->{$column};


### PR DESCRIPTION
This pull request fixes #236 - an issue where Runway was querying the `id` column on a related table. However, as no table was specified, the database would throw an error about the query being ambiguous about the table.

This PR fixes that by manually specifying the table for the `id` where statement. It also changes `id` to use the model's primary key (as this may not always be called `id`).