### PR TITLE
Ensure breadcrumbs are passed into inline publish form

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -39,6 +39,7 @@ class BaseFieldtype extends Relationship
         'resourceHasRoutes' => 'resourceHasRoutes',
         'permalink' => 'permalink',
         'resource' => 'resource',
+        'breadcrumbs' => 'breadcrumbs',
     ];
 
     protected function configFieldItems(): array


### PR DESCRIPTION
This pull request makes a tiny fix to ensure breadcrumbs show when opening the inline publish forms provided by Runway's relationship fieldtypes.

<img width="535" alt="image" src="https://user-images.githubusercontent.com/19637309/230732441-e9445580-5f0d-4255-8ccd-6958bd30c41b.png">
