### PR TITLE
Fix double requests, caused by columns changing

### DIFF
--- a/resources/js/components/Listing/ListingView.vue
+++ b/resources/js/components/Listing/ListingView.vue
@@ -78,8 +78,8 @@
                             <dropdown-list
                                 v-if="
                                     canViewRow(row) ||
-                                        canEditRow(row) ||
-                                        row.actions.length
+                                    canEditRow(row) ||
+                                    row.actions.length
                                 "
                             >
                                 <dropdown-item
@@ -98,7 +98,7 @@
                                     class="divider"
                                     v-if="
                                         (canViewRow(row) || canEditRow(row)) &&
-                                            row.actions.length
+                                        row.actions.length
                                     "
                                 />
 
@@ -149,26 +149,17 @@ export default {
         listingConfig: Object,
         initialColumns: Array,
         actionUrl: String,
+        initialPrimaryColumn: String,
     },
 
     data() {
-        let primaryColumn = ''
-
-        if (this.initialColumns) {
-            this.initialColumns.forEach(column => {
-                if (column.is_primary_column) {
-                    primaryColumn = column.handle
-                }
-            })
-        }
-
         return {
             listingKey: 'id',
             preferencesPrefix: this.listingConfig.preferencesPrefix ?? 'runway',
             requestUrl: this.listingConfig.requestUrl,
             columns: this.initialColumns,
             meta: {},
-            primaryColumn: `cell-${primaryColumn}`,
+            primaryColumn: `cell-${this.initialPrimaryColumn}`,
             deletingRow: false,
         }
     },
@@ -183,7 +174,9 @@ export default {
         },
 
         confirmDeleteRow(id, index, deleteUrl) {
-            this.visibleColumns = this.columns.filter(column => column.visible)
+            this.visibleColumns = this.columns.filter(
+                (column) => column.visible
+            )
             this.deletingRow = { id, index, deleteUrl }
         },
 
@@ -204,7 +197,7 @@ export default {
 
                     // location.reload()
                 })
-                .catch(e => {
+                .catch((e) => {
                     this.$toast.error(
                         e.response
                             ? e.response.data.message
@@ -217,7 +210,7 @@ export default {
             this.deletingRow = false
             setTimeout(() => {
                 this.visibleColumns = this.columns.filter(
-                    column => column.visible
+                    (column) => column.visible
                 )
             }, 50)
         },

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -26,6 +26,7 @@
             :listing-config='@json($listingConfig)'
             :initial-columns='@json($columns)'
             action-url="{{ $actionUrl }}"
+            initial-primary-column="{{ $primaryColumn }}"
         ></runway-listing-view>
      @else
         @include('statamic::partials.create-first', [

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -12,6 +12,7 @@ use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Support\Json;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Facades\Scope;
+use Statamic\Facades\User;
 use Statamic\Fields\Field;
 use Statamic\Http\Controllers\CP\CpController;
 
@@ -32,10 +33,15 @@ class ResourceController extends CpController
 
         $columns = $this->buildColumns($resource, $blueprint);
 
+        $preferredFirstColumn = isset(User::current()->preferences()['runway'][$resource->handle()]['columns'])
+            ? User::current()->preferences()['runway'][$resource->handle()]['columns'][0]
+            : $resource->titleField();
+
         return view('runway::index', [
             'title' => $resource->name(),
             'resource' => $resource,
             'recordCount' => $resource->model()->count(),
+            'primaryColumn' => $preferredFirstColumn,
             'columns' => $resource->blueprint()->columns()
                 ->filter(fn ($column) => in_array($column->field, collect($columns)->pluck('handle')->toArray()))
                 ->rejectUnlisted()

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -30,11 +30,16 @@ class ResourceController extends CpController
             'listingUrl' => cp_route('runway.index', ['resourceHandle' => $resource->handle()]),
         ];
 
+        $columns = $this->buildColumns($resource, $blueprint);
+
         return view('runway::index', [
             'title' => $resource->name(),
             'resource' => $resource,
             'recordCount' => $resource->model()->count(),
-            'columns' => $this->buildColumns($resource, $blueprint),
+            'columns' => $resource->blueprint()->columns()
+                ->filter(fn ($column) => in_array($column->field, collect($columns)->pluck('handle')->toArray()))
+                ->rejectUnlisted()
+                ->values(),
             'filters' => Scope::filters("runway_{$resourceHandle}"),
             'listingConfig' => $listingConfig,
             'actionUrl' => cp_route('runway.actions.run', ['resourceHandle' => $resourceHandle]),

--- a/src/Http/Controllers/Traits/HasListingColumns.php
+++ b/src/Http/Controllers/Traits/HasListingColumns.php
@@ -3,27 +3,18 @@
 namespace DoubleThreeDigital\Runway\Http\Controllers\Traits;
 
 use DoubleThreeDigital\Runway\Resource;
-use Statamic\Facades\User;
 
 trait HasListingColumns
 {
     protected function buildColumns(Resource $resource, $blueprint)
     {
-        $preferredFirstColumn = isset(User::current()->preferences()['runway'][$resource->handle()]['columns'])
-            ? User::current()->preferences()['runway'][$resource->handle()]['columns'][0]
-            : $resource->titleField();
-
         return collect($resource->listableColumns())
-            ->map(function ($columnKey) use ($blueprint, $preferredFirstColumn) {
+            ->map(function ($columnKey) use ($blueprint) {
                 $field = $blueprint->field($columnKey);
 
                 return [
                     'handle' => $columnKey,
-                    'title' => $field
-                        ? $field->display()
-                        : $field,
-                    'has_link' => $preferredFirstColumn === $columnKey,
-                    'is_primary_column' => $preferredFirstColumn === $columnKey,
+                    'title' => $field ? $field->display() : $field,
                 ];
             })
             ->toArray();


### PR DESCRIPTION
This pull request fixes #238.

When the `ListingView` component is initially loaded, it's provided with an `initialColumns` prop which is provided by the `ResourceController`. It then does a request to the server for models.

On this first request, if the columns differ (what was provided in the prop to what was returned in that second request), Statamic will do another request.

This is what was causing two requests to be done when loading the listing table.


As part of this fix, I've also had to re-work how the 'primary column' on the listing table is passed into the view. It's now a prop passed in from the view/controller, instead of being decided inside the `ListingView`'s data.