### PR TITLE
Use Slug as Fieldtype if Column Is Named Slug

### DIFF
--- a/src/Console/Commands/GenerateBlueprint.php
+++ b/src/Console/Commands/GenerateBlueprint.php
@@ -198,6 +198,10 @@ class GenerateBlueprint extends Command
             return null;
         }
 
+        if ($match['normal'] === 'text' && $column->getName() === 'slug') {
+            return 'slug';
+        }
+
         return $match['normal'];
     }
 


### PR DESCRIPTION
Thanks for this really cool addon.

In my case, I have a slug column on a model for which I would like to use the slug fieldtype. Obviously, I can just change the fieldtype in the blueprint but I thought it would be nice if it would just generate the blueprints accordingly based on the field name.

If you think this is too opinionated, feel free to just reject the PR. It was a quick win for me, so I thought I would open the PR and leave it up to you.