### PR TITLE
[5.x] Model Trait

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,19 +10,19 @@ title: 'Installation'
 
 ## Installing via Composer (recommended)
 
-First, run this command which will require Runway as a dependency of your app.
+First, you need to install Runway as a Composer dependency:
 
 ```
 composer require doublethreedigital/runway
 ```
 
-Once installed, you’ll want to publish the default configuration file.
+Next, publish the configuration file:
 
 ```
 php artisan vendor:publish --tag="runway-config"
 ```
 
-The configuration file will now be located at `config/runway.php`.
+The configuration file will have been published as `config/runway.php`.
 
 Now that everything's installed & published, you'll want to [configure Runway Resources](/resources) for each of the models you wish to be editable in Runway.
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -33,7 +33,7 @@ return [
 ];
 ```
 
-To define a resource, add an item to the `resources` array like so:
+There three steps to defining a Runway Resource: first you need to add it to Runway's `resources` array like so:
 
 ```php
 'resources' => [
@@ -43,9 +43,18 @@ To define a resource, add an item to the `resources` array like so:
 ],
 ```
 
-The key of the array item is the Eloquent model, and the array value contains the configuration for the resource.
+Second, you need to add the `HasRunwayResource` trait to your Eloquent model.
 
-The next thing you’ll want to do is create a blueprint for your model.
+```php
+// app/Models/Order.php
+
+class Order extends Model
+{
+    use HasRunwayResource; // [tl! add]
+}
+```
+
+Finally, you need to create a blueprint for your resource, there's [documentation on that below](#resource-blueprints). 🔽
 
 ## Resource Blueprints
 

--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -1,14 +1,15 @@
 <?php
 
-namespace DoubleThreeDigital\Runway;
+namespace DoubleThreeDigital\Runway\Data;
 
 use Carbon\CarbonInterface;
+use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Support\Json;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\Data\AbstractAugmented;
 use Statamic\Fields\Blueprint;
 
-class AugmentedRecord extends AbstractAugmented
+class AugmentedModel extends AbstractAugmented
 {
     protected $data;
 

--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -31,6 +31,8 @@ class AugmentedModel extends AbstractAugmented
     /**
      * Takes in an Eloquent model & augments it with the fields
      * from the resource's blueprint.
+     *
+     * TODO: Consider if we still need this or if what this does can be done elsewhere.
      */
     public static function augment(Model $record, Blueprint $blueprint): array
     {

--- a/src/Data/HasAugmentedInstance.php
+++ b/src/Data/HasAugmentedInstance.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Data;
+
+use Statamic\Contracts\Data\Augmented;
+
+/**
+ * This trait is a copy of HasAugmentedInstance built into Statamic BUT
+ * without the __get, __set, __call methods which mess with Eloquent.
+ */
+trait HasAugmentedInstance
+{
+    public function augmentedValue($key)
+    {
+        return $this->augmented()->get($key);
+    }
+
+    public function toAugmentedCollection($keys = null)
+    {
+        return $this->augmented()
+            ->withRelations($this->defaultAugmentedRelations())
+            ->select($keys ?? $this->defaultAugmentedArrayKeys());
+    }
+
+    public function toAugmentedArray($keys = null)
+    {
+        return $this->toAugmentedCollection($keys)->all();
+    }
+
+    public function toShallowAugmentedCollection()
+    {
+        return $this->augmented()->select($this->shallowAugmentedArrayKeys())->withShallowNesting();
+    }
+
+    public function toShallowAugmentedArray()
+    {
+        return $this->toShallowAugmentedCollection()->all();
+    }
+
+    public function augmented()
+    {
+        return $this->newAugmentedInstance();
+    }
+
+    abstract public function newAugmentedInstance(): Augmented;
+
+    protected function defaultAugmentedArrayKeys()
+    {
+        return null;
+    }
+
+    public function shallowAugmentedArrayKeys()
+    {
+        return ['id', 'title', 'api_url'];
+    }
+
+    protected function defaultAugmentedRelations()
+    {
+        return [];
+    }
+
+    public function toEvaluatedAugmentedArray($keys = null)
+    {
+        $collection = $this->toAugmentedCollection($keys);
+
+        // Can't just chain ->except() because it would return a new
+        // collection and the existing 'withRelations' would be lost.
+        if ($exceptions = $this->excludedEvaluatedAugmentedArrayKeys()) {
+            $collection = $collection
+                ->except($exceptions)
+                ->withRelations($collection->getRelations());
+        }
+
+        return $collection->withEvaluation()->toArray();
+    }
+
+    protected function excludedEvaluatedAugmentedArrayKeys()
+    {
+        return null;
+    }
+}

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\Runway;
 
+use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -280,7 +281,7 @@ class Resource
 
     public function augment(Model $model): array
     {
-        return AugmentedRecord::augment($model, $this->blueprint());
+        return AugmentedModel::augment($model, $this->blueprint());
     }
 
     public function titleField($field = null)

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -39,8 +39,7 @@ class Resource
         protected string $name,
         protected Blueprint $blueprint,
         protected array $config = []
-    )
-    {
+    ) {
         if (isset($config['cp_icon'])) {
             $this->cpIcon($config['cp_icon']);
         }

--- a/src/Routing/RoutingModel.php
+++ b/src/Routing/RoutingModel.php
@@ -2,7 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Routing;
 
-use DoubleThreeDigital\Runway\AugmentedRecord;
+use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
@@ -81,6 +81,6 @@ class RoutingModel implements Responsable, Augmentable
     {
         $blueprint = Runway::findResourceByModel($this->model)->blueprint();
 
-        return AugmentedRecord::augment($this->model, $blueprint);
+        return AugmentedModel::augment($this->model, $blueprint);
     }
 }

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -30,6 +30,10 @@ class Runway
                     $resource->name(Str::title($handle));
                 }
 
+                if (! in_array(Traits\HasRunwayResource::class, class_uses_recursive($model))) {
+                    throw new \Exception(__('The HasRunwayResource trait is missing from the [:model] model.', ['model' => $model]));
+                }
+
                 if (isset($config['title_field'])) {
                     $resource->titleField($config['title_field']);
                 }

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -3,8 +3,10 @@
 namespace DoubleThreeDigital\Runway;
 
 use DoubleThreeDigital\Runway\Exceptions\ResourceNotFound;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Statamic\Fields\Blueprint;
 
 class Runway
 {
@@ -14,73 +16,38 @@ class Runway
     {
         static::$resources = collect(config('runway.resources'))
             ->mapWithKeys(function ($config, $model) {
+                $blueprint = null;
                 $handle = Str::lower(class_basename($model));
 
                 if (isset($config['handle'])) {
                     $handle = $config['handle'];
                 }
 
-                $resource = (new Resource())
-                    ->handle($handle)
-                    ->model($model);
-
-                if (isset($config['name'])) {
-                    $resource->name($config['name']);
-                } else {
-                    $resource->name(Str::title($handle));
-                }
-
                 if (! in_array(Traits\HasRunwayResource::class, class_uses_recursive($model))) {
                     throw new \Exception(__('The HasRunwayResource trait is missing from the [:model] model.', ['model' => $model]));
                 }
 
-                if (isset($config['title_field'])) {
-                    $resource->titleField($config['title_field']);
+                if (! isset($config['blueprint'])) {
+                    throw new \Exception(__('The [:model] model is missing a blueprint.', ['model' => $model]));
                 }
 
-                if (isset($config['blueprint'])) {
-                    $resource->blueprint($config['blueprint']);
+                if (is_string($config['blueprint'])) {
+                    $blueprint = Blueprint::find($config['blueprint']);
                 }
 
-                if (isset($config['cp_icon'])) {
-                    $resource->cpIcon($config['cp_icon']);
+                if (is_array($config['blueprint'])) {
+                    $blueprint = Blueprint::make()
+                        ->setHandle($handle)
+                        ->setContents($config['blueprint']);
                 }
 
-                if (isset($config['hidden'])) {
-                    $resource->hidden($config['hidden']);
-                }
-
-                if (isset($config['route'])) {
-                    $resource->route($config['route']);
-                }
-
-                if (isset($config['template'])) {
-                    $resource->template($config['template']);
-                }
-
-                if (isset($config['layout'])) {
-                    $resource->layout($config['layout']);
-                }
-
-                if (isset($config['graphql'])) {
-                    $resource->graphqlEnabled($config['graphql']);
-                }
-
-                if (isset($config['read_only'])) {
-                    $resource->readOnly($config['read_only']);
-                }
-
-                if (isset($config['with'])) {
-                    $resource->eagerLoadingRelations($config['with']);
-                }
-
-                if (isset($config['order_by'])) {
-                    $resource->orderBy($config['order_by']);
-                }
-
-                if (isset($config['order_by_direction'])) {
-                    $resource->orderByDirection($config['order_by_direction']);
-                }
+                $resource = new Resource(
+                    handle: $handle,
+                    model: $model instanceof Model ? $model : new $model(),
+                    name: $config['name'] ?? Str::title($handle),
+                    blueprint: $blueprint,
+                    config: $config,
+                );
 
                 return [$handle => $resource];
             })

--- a/src/Search/Searchable.php
+++ b/src/Search/Searchable.php
@@ -2,7 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Search;
 
-use DoubleThreeDigital\Runway\AugmentedRecord;
+use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use DoubleThreeDigital\Runway\Runway;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
@@ -76,6 +76,6 @@ class Searchable implements Contract, ContainsQueryableValues, Augmentable
 
     public function newAugmentedInstance(): Augmented
     {
-        return new AugmentedRecord($this->model);
+        return new AugmentedModel($this->model);
     }
 }

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Traits;
+
+use Illuminate\Support\Traits\Conditionable;
+
+trait HasRunwayResource
+{
+    use Conditionable;
+
+    //
+}

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -13,7 +13,6 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 trait HasRunwayResource
 {
     use HasAugmentedInstance, FluentlyGetsAndSets;
-
     use ResolvesValues {
         resolveGqlValue as traitResolveGqlValue;
     }

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -4,6 +4,8 @@ namespace DoubleThreeDigital\Runway\Traits;
 
 use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use DoubleThreeDigital\Runway\Data\HasAugmentedInstance;
+use DoubleThreeDigital\Runway\Resource;
+use DoubleThreeDigital\Runway\Runway;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\GraphQL\ResolvesValues;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
@@ -19,5 +21,10 @@ trait HasRunwayResource
     public function newAugmentedInstance(): Augmented
     {
         return new AugmentedModel($this);
+    }
+
+    public function runwayResource(): Resource
+    {
+        return Runway::findResourceByModel($this);
     }
 }

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -2,11 +2,21 @@
 
 namespace DoubleThreeDigital\Runway\Traits;
 
-use Illuminate\Support\Traits\Conditionable;
+use DoubleThreeDigital\Runway\AugmentedRecord;
+use DoubleThreeDigital\Runway\Data\HasAugmentedInstance;
+use Statamic\Contracts\Data\Augmented;
+use Statamic\GraphQL\ResolvesValues;
 
 trait HasRunwayResource
 {
-    use Conditionable;
+    use HasAugmentedInstance;
 
-    //
+    use ResolvesValues {
+        resolveGqlValue as traitResolveGqlValue;
+    }
+
+    public function newAugmentedInstance(): Augmented
+    {
+        return new AugmentedRecord($this);
+    }
 }

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -2,7 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Traits;
 
-use DoubleThreeDigital\Runway\AugmentedRecord;
+use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use DoubleThreeDigital\Runway\Data\HasAugmentedInstance;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\GraphQL\ResolvesValues;
@@ -17,6 +17,6 @@ trait HasRunwayResource
 
     public function newAugmentedInstance(): Augmented
     {
-        return new AugmentedRecord($this);
+        return new AugmentedModel($this);
     }
 }

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -6,10 +6,11 @@ use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use DoubleThreeDigital\Runway\Data\HasAugmentedInstance;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\GraphQL\ResolvesValues;
+use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 trait HasRunwayResource
 {
-    use HasAugmentedInstance;
+    use HasAugmentedInstance, FluentlyGetsAndSets;
 
     use ResolvesValues {
         resolveGqlValue as traitResolveGqlValue;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\Runway\Tests;
 
 use DoubleThreeDigital\Runway\Routing\Traits\RunwayRoutes;
 use DoubleThreeDigital\Runway\ServiceProvider;
+use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -239,7 +240,7 @@ abstract class TestCase extends OrchestraTestCase
 
 class Post extends Model
 {
-    use RunwayRoutes;
+    use RunwayRoutes, HasRunwayResource;
 
     protected $fillable = [
         'title', 'slug', 'body', 'author_id',
@@ -274,6 +275,8 @@ class Post extends Model
 
 class Author extends Model
 {
+    use HasRunwayResource;
+
     protected $fillable = [
         'name',
     ];


### PR DESCRIPTION
This pull request introduces the requirement for developers to pull in the `HasRunwayResource` trait into their Eloquent models being used by Runway.

For the longest time, I've wanted to avoid developers needing to add any kind of trait/base class to Eloquent models in the case of simplicity.

The result of this has meant features like GraphQL, routing & search have needed to be hacked together with proxy classes, like `RoutingModel` which sit in-between the feature and the Eloquent model.

After looking into #252, I've realised that we probably do need to add a trait to Eloquent models. Not only to fix that bug but it'll help us to make Runway cleaner & should reduce confusion when I/other developers look at the code 😅

Alongside introducing the requirement for the traits, this PR also does some tiny bits of refactoring elsewhere, like changing how we make `Resource` objects.

## Upgrade Steps

Upon upgrading to v5.0, you will need to add the `HasRunwayResource` trait to your Eloquent model. 

---

Fixes #252