### PR TITLE
Qualify the routeKey when querying

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -159,7 +159,7 @@ class ResourceController extends CpController
     public function edit(EditRequest $request, $resourceHandle, $record)
     {
         $resource = Runway::findResource($resourceHandle);
-        $record = $resource->model()->where($resource->routeKey(), $record)->first();
+        $record = $resource->model()->where($resource->model()->qualifyColumn($resource->routeKey()), $record)->first();
 
         $values = [];
         $blueprintFieldKeys = $resource->blueprint()->fields()->all()->keys()->toArray();
@@ -232,7 +232,7 @@ class ResourceController extends CpController
     public function update(UpdateRequest $request, $resourceHandle, $record)
     {
         $resource = Runway::findResource($resourceHandle);
-        $record = $resource->model()->where($resource->routeKey(), $record)->first();
+        $record = $resource->model()->where($resource->model()->qualifyColumn($resource->routeKey()), $record)->first();
 
         foreach ($resource->blueprint()->fields()->all() as $fieldKey => $field) {
             $processedValue = $field->fieldtype()->process($request->get($fieldKey));

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -159,7 +159,10 @@ class ResourceController extends CpController
     public function edit(EditRequest $request, $resourceHandle, $record)
     {
         $resource = Runway::findResource($resourceHandle);
-        $record = $resource->model()->where($resource->model()->qualifyColumn($resource->routeKey()), $record)->first();
+
+        $record = $resource->model()
+            ->where($resource->model()->qualifyColumn($resource->routeKey()), $record)
+            ->first();
 
         $values = [];
         $blueprintFieldKeys = $resource->blueprint()->fields()->all()->keys()->toArray();
@@ -232,7 +235,10 @@ class ResourceController extends CpController
     public function update(UpdateRequest $request, $resourceHandle, $record)
     {
         $resource = Runway::findResource($resourceHandle);
-        $record = $resource->model()->where($resource->model()->qualifyColumn($resource->routeKey()), $record)->first();
+
+        $record = $resource->model()
+            ->where($resource->model()->qualifyColumn($resource->routeKey()), $record)
+            ->first();
 
         foreach ($resource->blueprint()->fields()->all() as $fieldKey => $field) {
             $processedValue = $field->fieldtype()->process($request->get($fieldKey));
@@ -283,7 +289,7 @@ class ResourceController extends CpController
                     $relationshipName = $resource->eagerLoadingRelations()->get($field->handle()) ?? $field->handle();
 
                     $record->{$field->handle()} = $record->{$relationshipName}()
-                        ->select($relatedResource->databaseTable().'.'.$relatedResource->primaryKey(), $column)
+                        ->select($resource->model()->qualifyColumn($relatedResource->primaryKey()), $column)
                         ->get()
                         ->each(function ($model) use ($relatedResource, $column) {
                             $model->title = $model->{$column};


### PR DESCRIPTION
This is needed so when you've joined something and there are duplicated columns you won't get the `Integrity constraint violation` error as the table will be prefixed.

An example is this model on top of a Magento 2 database to get all the manufacturers:
```
class AttributeOptionValue extends Model
{
    protected $table = 'eav_attribute_option';

    protected $primaryKey = 'option_id';

    protected static function booting()
    {
        static::addGlobalScope(function (Builder $builder) {
            $builder
                ->select('eav_attribute_option.option_id AS option_id')
                ->addSelect('eav_attribute_option.sort_order')
                ->addSelect('admin_value.value AS value_admin')
                ->selectRaw('IFNULL(store_value.value, admin_value.value) AS value_store')
                ->leftJoin('eav_attribute_option_value AS admin_value', function ($join) {
                    $join->on('admin_value.option_id', '=', 'eav_attribute_option.option_id')
                         ->where('admin_value.store_id', 0);
                })
                ->leftJoin('eav_attribute_option_value AS store_value', function ($join) {
                    $join->on('store_value.option_id', '=', 'eav_attribute_option.option_id')
                         ->where('store_value.store_id', Site::selected()->attributes['magento_store_id']);
                })
                ->where('attribute_id', 83);
        });
    }
}
```

With this configuration:
```
AttributeOptionValue::class => [
    'name' => 'Manufacturers',
    'read_only' => true,
    'title_field' => 'value_store',
    'cp_icon' => 'taxonomy',
    'blueprint' => [
        'sections' => [
            'main' => [
                'fields' => [
                    ['handle' => 'option_id', 'field' => ['type' => 'integer']],
                    ['handle' => 'sort_order', 'field' => ['type' => 'integer']],
                    ['handle' => 'value_admin', 'field' => ['type' => 'text']],
                    ['handle' => 'value_store', 'field' => ['type' => 'text']],
                ]
            ]
        ]
    ]
],
```