### PR TITLE
Extra data option and access to the resource from scopes

### DIFF
--- a/docs/control-panel.md
+++ b/docs/control-panel.md
@@ -158,7 +158,7 @@ If you don't want to return everything, you may add a scope (`runwayListing`) to
 ```php
 class YourModel extends Model
 {
-	public function scopeRunwayListing($query)
+	public function scopeRunwayListing($query, $resource)
 	{
 		return $query->where('something', true);
 	}
@@ -172,7 +172,7 @@ On top of scoping your Control Panel results, you may also scope how Runway sear
 ```php
 class YourModel extends Model
 {
-	public function scopeRunwaySearch($query, $searchString)
+	public function scopeRunwaySearch($query, $searchString, $resource)
 	{
 		// Your own search logic
 	}

--- a/docs/kb-articles/multisite.md
+++ b/docs/kb-articles/multisite.md
@@ -15,7 +15,7 @@ However, there is an easy way to scope the model results you get to only those r
 
 use Statamic\Facades\Site;
 
-public function scopeRunway($query)
+public function scopeRunway($query, $resource)
 {
     $query->where('site', Site::selected()->handle());
 }

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -227,6 +227,21 @@ If you'd like to specify a different field, you may do so by setting the `title_
 ],
 ```
 
+### Extra data
+
+In case you need to provide some extra data you can do so by setting the `extra` option on your resource.
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+	    'name' => 'Orders',
+		'extra' => 'Something you may need within a scope',
+	],
+],
+```
+
+This can be useful within a [scope](/control-panel#content-scoping-control-panel-results) as you've access to the resource from there.
+
 ## Actions
 
 In much the same way with entries, you can create custom Actions which will be usable in the listing tables provided by Runway.

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -92,7 +92,7 @@ class BaseFieldtype extends Relationship
             ->orderBy($resource->primaryKey(), 'ASC');
 
         if ($query->hasNamedScope('runwayListing')) {
-            $query->runwayListing();
+            $query->runwayListing($resource);
         }
 
         return $query
@@ -101,8 +101,8 @@ class BaseFieldtype extends Relationship
 
                 $query->when(
                     $query->hasNamedScope('runwaySearch'),
-                    function ($query) use ($searchQuery) {
-                        $query->runwaySearch($searchQuery);
+                    function ($query) use ($searchQuery, $resource) {
+                        $query->runwaySearch($searchQuery, $resource);
                     },
                     function ($query) use ($searchQuery, $resource) {
                         $resource->blueprint()->fields()->items()

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -29,7 +29,7 @@ class ResourceListingController extends CpController
             ->orderBy($sortField, $sortDirection);
 
         if ($query->hasNamedScope('runwayListing')) {
-            $query->runwayListing();
+            $query->runwayListing($resource);
         }
 
         $query->with($resource->eagerLoadingRelations()->values()->all());
@@ -44,8 +44,8 @@ class ResourceListingController extends CpController
         if ($searchQuery = $request->input('search')) {
             $query->when(
                 $query->hasNamedScope('runwaySearch'),
-                function ($query) use ($searchQuery) {
-                    $query->runwaySearch($searchQuery);
+                function ($query) use ($searchQuery, $resource) {
+                    $query->runwaySearch($searchQuery, $resource);
                 },
                 function ($query) use ($searchQuery, $blueprint) {
                     $blueprint->fields()->items()

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -33,6 +33,8 @@ class Resource
 
     protected $readOnly;
 
+    protected $extra;
+
     protected $eagerLoadingRelations;
 
     protected $orderBy;
@@ -168,6 +170,12 @@ class Resource
     public function readOnly($readOnly = null)
     {
         return $this->fluentlyGetOrSet('readOnly')
+            ->args(func_get_args());
+    }
+
+    public function extra($extra = null)
+    {
+        return $this->fluentlyGetOrSet('extra')
             ->args(func_get_args());
     }
 

--- a/src/Runway.php
+++ b/src/Runway.php
@@ -66,6 +66,10 @@ class Runway
                     $resource->readOnly($config['read_only']);
                 }
 
+                if (isset($config['extra'])) {
+                    $resource->extra($config['extra']);
+                }
+
                 if (isset($config['with'])) {
                     $resource->eagerLoadingRelations($config['with']);
                 }


### PR DESCRIPTION
With this we can do things like:
```
AttributeOptionValue::class => [
    'name' => 'Manufacturers',
    'extra' => [
        'attribute_id' => 83,
    ],
],
```

```
public function scopeRunwayListing($query, $resource)
{
    return $query->where('attribute_id', $resource->extra()['attribute_id']);
}
```

~And with this creating an option to re-use models.~ https://github.com/duncanmcclean/runway/issues/256