### PR TITLE
[5.x] Add `config` method to resource

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\Runway;
 
 use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Statamic\Fields\Blueprint;
@@ -113,6 +114,11 @@ class Resource
     public function blueprint()
     {
         return $this->blueprint;
+    }
+
+    public function config(): Collection
+    {
+        return collect($this->config);
     }
 
     public function cpIcon($cpIcon = null)


### PR DESCRIPTION
This pull request adds a `config` method to the `Resource` class which allows you to grab any of the values from your Runway configuration array.

You can simply access anything you want like so:

```php
\App\Models\Article::class => [
    // ...
    'blah' => 'blahblah',
],
```

```php
$resource = Runway::findResource('article');

$resource->config()->get('blah'); // returns "blahblah"
```