### PR TITLE
Re-ordering on Has Many fieldtype

### DIFF
--- a/resources/js/components/Fieldtypes/HasManyRelatedItem.vue
+++ b/resources/js/components/Fieldtypes/HasManyRelatedItem.vue
@@ -33,7 +33,7 @@
             />
         </template>
 
-        <div v-else class="item select-none" :class="{ invalid: item.invalid }">
+        <template v-else>
             <div class="item-move" v-if="sortable">&nbsp;</div>
 
             <div class="item-inner">
@@ -89,7 +89,7 @@
                     />
                 </dropdown-list>
             </div>
-        </div>
+        </template>
     </div>
 </template>
 

--- a/resources/js/components/Fieldtypes/Relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/Fieldtypes/Relationship/RelationshipFieldtype.vue
@@ -124,7 +124,11 @@ export default {
         },
 
         canReorder() {
-            return this.maxItems > 1 && this.config.reorderable === true && this.config.reorderable_column !== undefined
+            return (
+                this.maxItems > 1 &&
+                this.config.reorderable === true &&
+                this.config.order_column !== undefined
+            )
         },
 
         statusIcons() {
@@ -148,7 +152,7 @@ export default {
         },
 
         replicatorPreview() {
-            return this.value.map(id => {
+            return this.value.map((id) => {
                 const item = _.findWhere(this.meta.data, { id })
                 return item ? item.title : id
             })

--- a/resources/js/components/Fieldtypes/Relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/Fieldtypes/Relationship/RelationshipFieldtype.vue
@@ -124,7 +124,7 @@ export default {
         },
 
         canReorder() {
-            return this.maxItems > 1
+            return this.maxItems > 1 && this.config.reorderable === true && this.config.reorderable_column !== undefined
         },
 
         statusIcons() {

--- a/resources/js/components/Fieldtypes/Relationship/RelationshipTableMode.vue
+++ b/resources/js/components/Fieldtypes/Relationship/RelationshipTableMode.vue
@@ -10,7 +10,7 @@
                 class="mb-2"
                 :rows="items"
                 :columns="columns"
-                :sort="true"
+                :sort="!canReorder"
                 :sortColumm="sortColumn"
                 :sortDirection="sortDirection"
             >
@@ -24,7 +24,7 @@
                     <data-list-table
                         :loading="loading"
                         :reorderable="canReorder"
-                        :sortable="true"
+                        :sortable="!canReorder"
                         class="card p-1"
                         @sorted="sorted"
                         @reordered="reordered"

--- a/resources/js/components/Fieldtypes/Relationship/RelationshipTableMode.vue
+++ b/resources/js/components/Fieldtypes/Relationship/RelationshipTableMode.vue
@@ -23,10 +23,11 @@
 
                     <data-list-table
                         :loading="loading"
-                        :reorderable="false"
+                        :reorderable="canReorder"
                         :sortable="true"
                         class="card p-1"
                         @sorted="sorted"
+                        @reordered="reordered"
                     >
                         <template v-if="items.length === 0" slot="tbody-start">
                             <div
@@ -69,7 +70,7 @@
                                     class="divider"
                                     v-if="
                                         (canViewRow(row) || canEditRow(row)) &&
-                                            row.actions.length
+                                        row.actions.length
                                     "
                                 />
 
@@ -248,8 +249,8 @@ export default {
 
     computed: {
         items() {
-            return this.value.map(selection => {
-                const data = _.find(this.data, item => item.id == selection)
+            return this.value.map((selection) => {
+                const data = _.find(this.data, (item) => item.id == selection)
 
                 if (!data) return { id: selection, title: selection }
 
@@ -320,7 +321,7 @@ export default {
 
             this.initializing = true
 
-            let data = this.data.map(item => {
+            let data = this.data.map((item) => {
                 if (item.id == responseData.id) {
                     return {
                         ...item,
@@ -339,6 +340,15 @@ export default {
         sorted(column, direction) {
             this.sortColumn = column
             this.sortDirection = direction
+        },
+
+        reordered(value) {
+            // this.value = value.map((item) => item.id)
+
+            this.$emit(
+                'input',
+                value.map((item) => item.id)
+            )
         },
 
         update(selections) {
@@ -373,7 +383,7 @@ export default {
 
             return this.$axios
                 .post(this.itemDataUrl, { site: this.site, selections })
-                .then(response => {
+                .then((response) => {
                     this.$emit('item-data-updated', response.data.data)
                 })
                 .finally(() => {
@@ -390,13 +400,13 @@ export default {
                 plugins: [Plugins.SwapAnimation],
                 delay: 200,
             })
-                .on('drag:start', e => {
+                .on('drag:start', (e) => {
                     this.value.length === 1 ? e.cancel() : this.$emit('focus')
                 })
-                .on('drag:stop', e => {
+                .on('drag:stop', (e) => {
                     this.$emit('blur')
                 })
-                .on('sortable:stop', e => {
+                .on('sortable:stop', (e) => {
                     const val = [...this.value]
                     val.splice(e.newIndex, 0, val.splice(e.oldIndex, 1)[0])
                     this.update(val)
@@ -411,12 +421,12 @@ export default {
         selectFieldSelected(selectedItemData) {
             this.$emit(
                 'item-data-updated',
-                selectedItemData.map(item => ({
+                selectedItemData.map((item) => ({
                     id: item.id,
                     title: item.title,
                 }))
             )
-            this.update(selectedItemData.map(item => item.id))
+            this.update(selectedItemData.map((item) => item.id))
         },
 
         setLoadingProgress(state) {

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -65,6 +65,7 @@ class BaseFieldtype extends Relationship
                     ->mapWithKeys(fn ($resource) => [$resource->handle() => $resource->name()])
                     ->toArray(),
                 'width' => 50,
+                'validate' => 'required',
             ],
             'create' => [
                 'display' => __('Allow Creating'),

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -145,6 +145,22 @@ class HasManyFieldtype extends BaseFieldtype
                 ]);
             });
 
+        // If reordering is enabled, update all models with their new sort order.
+        if ($this->config('reorderable') && $orderColumn = $this->config('reorderable_column')) {
+            collect($data)
+                ->each(function ($relatedId, $index) use ($relatedResource, $orderColumn) {
+                    $model = $relatedResource->model()->find($relatedId);
+
+                    if ($model->{$orderColumn} === $index) {
+                        return;
+                    }
+
+                    $model->update([
+                        $orderColumn => $index,
+                    ]);
+                });
+        }
+
         return null;
     }
 

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -46,12 +46,12 @@ class HasManyFieldtype extends BaseFieldtype
                 'type' => 'toggle',
                 'width' => 50,
             ],
-            // TODO: Somehow make this work in cases where the pivot table contains the reorderable column, rather than the model itself.
-            'reorderable_column' => [
-                'display' => __('Reorderable Column'),
-                'instructions' => __('This is the column which will be used to store the sort order.'),
+            'order_column' => [
+                'display' => __('Order Column'),
+                'instructions' => __('Which column should be used to keep track of the order?'),
                 'type' => 'text',
                 'width' => 50,
+                'placeholder' => 'sort_order',
                 'if' => [
                     'reorderable' => true,
                 ],
@@ -146,7 +146,7 @@ class HasManyFieldtype extends BaseFieldtype
             });
 
         // If reordering is enabled, update all models with their new sort order.
-        if ($this->config('reorderable') && $orderColumn = $this->config('reorderable_column')) {
+        if ($this->config('reorderable') && $orderColumn = $this->config('order_column')) {
             collect($data)
                 ->each(function ($relatedId, $index) use ($relatedResource, $orderColumn) {
                     $model = $relatedResource->model()->find($relatedId);

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -40,6 +40,22 @@ class HasManyFieldtype extends BaseFieldtype
                 ],
                 'width' => 50,
             ],
+            'reorderable' => [
+                'display' => __('Reorderable?'),
+                'instructions' => __('Can the models be reordered?'),
+                'type' => 'toggle',
+                'width' => 50,
+            ],
+            // TODO: Somehow make this work in cases where the pivot table contains the reorderable column, rather than the model itself.
+            'reorderable_column' => [
+                'display' => __('Reorderable Column'),
+                'instructions' => __('This is the column which will be used to store the sort order.'),
+                'type' => 'text',
+                'width' => 50,
+                'if' => [
+                    'reorderable' => true,
+                ],
+            ],
         ];
 
         return array_merge(parent::configFieldItems(), $config);

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -5,7 +5,7 @@ namespace DoubleThreeDigital\Runway\Fieldtypes;
 use DoubleThreeDigital\Runway\Runway;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Support\Facades\Request;
+use Statamic\Facades\Blink;
 use Statamic\Facades\GraphQL;
 
 class HasManyFieldtype extends BaseFieldtype
@@ -80,14 +80,18 @@ class HasManyFieldtype extends BaseFieldtype
     public function process($data)
     {
         // Determine whether or not this field is on a resource or a collection
-        $resourceHandle = request()->route('resourceHandle');
+        $resourceHandle = request()->route('resourceHandle') ?? Blink::get('RunwayRouteResource');
 
         if (! $resourceHandle) {
             return $data;
         }
 
         $resource = Runway::findResource($resourceHandle);
-        $record = $resource->model()->firstWhere($resource->routeKey(), (int) Request::route('record'));
+
+        $record = $resource->model()->firstWhere(
+            $resource->routeKey(),
+            request()->route('record') ?? Blink::get('RunwayRouteRecord')
+        );
 
         // If we're adding HasMany relations on a model that doesn't exist yet,
         // return a closure that will be run post-save.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -242,7 +242,7 @@ class Post extends Model
     use RunwayRoutes;
 
     protected $fillable = [
-        'title', 'slug', 'body', 'author_id',
+        'title', 'slug', 'body', 'author_id', 'sort_order',
     ];
 
     protected $appends = [

--- a/tests/__fixtures__/database/migrations/2020_12_12_220453_create_posts_table.php
+++ b/tests/__fixtures__/database/migrations/2020_12_12_220453_create_posts_table.php
@@ -19,6 +19,7 @@ class CreatePostsTable extends Migration
             $table->string('slug');
             $table->longText('body');
             $table->integer('author_id');
+            $table->integer('sort_order')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This pull request implements #228, allowing for re-ordering of items in the Has Many fieldtype. This feature will work both in the default (stack) mode and in Table mode.

This feature has been built originally for v4.x (because it's where we need it now) but I'll port it for v5.x in the next couple of days.

![Notification-Centre-Notification-Center-4-May-2023](https://user-images.githubusercontent.com/19637309/236194888-0a2510ac-9253-4ea5-a732-71522f4513ca.gif)

## Enabling

To enable this feature, you'll need to toggle 'Reorderable?' and set a 'Order Column' so Runway knows where to persist the ordering.

![image](https://user-images.githubusercontent.com/19637309/236193939-66953c6a-6ece-412f-a44a-11a7b9eb3ad1.png)

```yaml
 - handle: lessons
   field:
       resource: lesson
       create: true
       display: Lessons
       type: has_many
       icon: has_many
       listable: hidden
       instructions_position: above
       visibility: visible
       always_save: false
       mode: table
       reorderable: true
       order_column: sort_order
```