### PR TITLE
Fix GraphQL not resolving entries

### DIFF
--- a/src/GraphQL/ResourceType.php
+++ b/src/GraphQL/ResourceType.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\GraphQL;
 
+use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -10,6 +11,8 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Rebing\GraphQL\Support\Type;
 use Statamic\Facades\GraphQL;
+use Statamic\Contracts\Query\Builder;
+use Statamic\Fields\Value;
 
 class ResourceType extends Type
 {
@@ -44,7 +47,17 @@ class ResourceType extends Type
                 $model = $resource->model()->firstWhere($resource->primaryKey(), $model);
             }
 
-            return $model->{$info->fieldName};
+            $value = AugmentedModel::augment($model, $this->resource->blueprint())[$info->fieldName];
+
+            if ($value instanceof Value) {
+                $value = $value->value();
+            }
+
+            if ($value instanceof Builder) {
+                $value = $value->get();
+            }
+
+            return $value;
         };
     }
 


### PR DESCRIPTION
This pull request fixes an issue where some values would error out when being fetched using the GraphQL API. This was happening due to Runway not augmenting values before returning them back to the GraphQL package.

This fix will do for now and I'll open another PR shortly to hopefully make GraphQL mirror entries in Statamic Core a little better.