### PR TITLE
Add select parameter to Runway tag

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -206,11 +206,13 @@ class BaseFieldtype extends Relationship
                 if (! $record instanceof Model) {
                     $eagerLoadingRelations = collect($this->config('with') ?? [])->join(',');
 
-                    $record = Blink::once("Runway::{$this->config('resource')}::{$record}::{$eagerLoadingRelations}", fn () => $resource->model()
-                        ->when($this->config('with'), function ($query) {
-                            $query->with(Arr::wrap($this->config('with')));
-                        })
-                        ->firstWhere($resource->primaryKey(), $record));
+                    $record = Blink::once("Runway::{$this->config('resource')}::{$record}}::{$eagerLoadingRelations}", function () use ($resource, $record) {
+                        return $resource->model()
+                            ->when($this->config('with'), function ($query) {
+                                $query->with(Arr::wrap($this->config('with')));
+                            })
+                            ->firstWhere($resource->primaryKey(), $record);
+                    });
                 }
 
                 if (! $record) {

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -6,8 +6,10 @@ use DoubleThreeDigital\Runway\Exceptions\ResourceNotFound;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
+use Statamic\Facades\Blink;
 use Statamic\Tags\Tags;
 
 class RunwayTag extends Tags
@@ -27,6 +29,10 @@ class RunwayTag extends Tags
         }
 
         $query = $resource->model()->query();
+
+        if ($select = $this->params->get('select')) {
+            $query->select(explode(',', (string) $select));
+        }
 
         if ($scopes = $this->params->get('scope')) {
             $scopes = explode('|', (string) $scopes);
@@ -116,7 +122,11 @@ class RunwayTag extends Tags
     protected function augmentRecords($query, Resource $resource)
     {
         return collect($query)
-            ->map(fn ($record, $key) => $resource->augment($record))
+            ->map(function ($record, $key) use ($resource) {
+                return Blink::once("Runway::Tag::AugmentRecords::{$resource->handle()}::{$record->{$resource->primaryKey()}}", function () use ($resource, $record) {
+                    return $resource->augment($record);
+                });
+            })
             ->toArray();
     }
 

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -46,6 +46,40 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
+    public function can_get_records_with_select_parameter()
+    {
+        $posts = $this->postFactory(5);
+
+        $this->tag->setParameters([
+            'select' => 'id,title,slug',
+        ]);
+
+        $usage = $this->tag->wildcard('post');
+
+        $this->assertSame(5, count($usage));
+
+        $this->assertSame((string) $usage[0]['title'], $posts[0]->title);
+        $this->assertSame((string) $usage[0]['slug'], $posts[0]->slug);
+        $this->assertEmpty((string) $usage[0]['body']);
+
+        $this->assertSame((string) $usage[1]['title'], $posts[1]->title);
+        $this->assertSame((string) $usage[1]['slug'], $posts[1]->slug);
+        $this->assertEmpty((string) $usage[1]['body']);
+
+        $this->assertSame((string) $usage[2]['title'], $posts[2]->title);
+        $this->assertSame((string) $usage[2]['slug'], $posts[2]->slug);
+        $this->assertEmpty((string) $usage[2]['body']);
+
+        $this->assertSame((string) $usage[3]['title'], $posts[3]->title);
+        $this->assertSame((string) $usage[3]['slug'], $posts[3]->slug);
+        $this->assertEmpty((string) $usage[3]['body']);
+
+        $this->assertSame((string) $usage[4]['title'], $posts[4]->title);
+        $this->assertSame((string) $usage[4]['slug'], $posts[4]->slug);
+        $this->assertEmpty((string) $usage[4]['body']);
+    }
+
+    /** @test */
     public function can_get_records_with_scope_parameter()
     {
         $posts = $this->postFactory(5);


### PR DESCRIPTION
This pull request adds a new `select` parameter to the Runway tag to allow you to improve performance by only using certain columns.

```antlers
{{ runway:posts select="id,title" }}
  {{ title }} - {{ id }} <!-- will be returned -->
  {{ description }} <!-- will not be returned -->
{{ /runway:posts }}
```