### PR TITLE
Belongs To Fieldtype: Allow overriding Eloquent relationship names

### DIFF
--- a/src/Fieldtypes/BelongsToFieldtype.php
+++ b/src/Fieldtypes/BelongsToFieldtype.php
@@ -23,6 +23,12 @@ class BelongsToFieldtype extends BaseFieldtype
                 'type' => 'text',
                 'width' => 50,
             ],
+            'relationship_name' => [
+                'display' => __('Relationship Name'),
+                'instructions' => __('The name of the Eloquent relationship this field should use. When left blank, Runway will attempt to guess it.'),
+                'type' => 'text',
+                'width' => 50,
+            ],
         ];
 
         return array_merge($config, parent::configFieldItems());

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -190,6 +190,14 @@ class Resource
                         ->mapWithKeys(function ($field) {
                             $relationName = $field['handle'];
 
+                            // If the field has a `relationship_name` config key, use that instead.
+                            // Sometimes a column name will be different to the relationship name
+                            // (the method on the model) so our magic won't be able to figure out what's what.
+                            // Eg. standard_parent_id -> parent
+                            if (isset($field['field']['relationship_name'])) {
+                                $relationName = $field['field']['relationship_name'];
+                            }
+
                             // If field handle is `author_id`, strip off the `_id`
                             if (str_contains($relationName, '_id')) {
                                 $relationName = Str::replaceLast('_id', '', $relationName);


### PR DESCRIPTION
This pull request allows for overriding the Eloquent relationship names for Belongs To & Has Many fields.

By default, Runway will take the field's handle and attempt to do some *magic* to convert it into a relationship name (the name of the relationship method in the Eloquent model).

However, in some cases this logic may fail. For example, if the field handle is completely different from the relationship name, you'd end up seeing an error like in #268.

This is only really needed in the case of the Belongs To fieldtype since the field will be the column name but the relationship method could be different. In the case of the Has Many fieldtype, the field will use the relationship name.

Fixes #268