### PR TITLE
Enable filters on Runway Listing

### DIFF
--- a/resources/js/components/Listing/RunwayListing.vue
+++ b/resources/js/components/Listing/RunwayListing.vue
@@ -59,7 +59,7 @@
                         </div>
                     </div>
 
-                    <div v-show="showFilters">
+                    <div>
                         <data-list-filters
                             :filters="filters"
                             :active-preset="activePreset"

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -47,7 +47,7 @@ class ResourceController extends CpController
                 ->filter(fn ($column) => in_array($column->field, collect($columns)->pluck('handle')->toArray()))
                 ->rejectUnlisted()
                 ->values(),
-            'filters' => Scope::filters("runway_{$resourceHandle}"),
+            'filters' => Scope::filters('runway', ['resource' => $resource->handle()]),
             'listingConfig' => $listingConfig,
             'actionUrl' => cp_route('runway.actions.run', ['resourceHandle' => $resourceHandle]),
         ]);

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -8,6 +8,7 @@ use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
+use Statamic\Query\Scopes\Scope;
 
 class ResourceListingController extends CpController
 {
@@ -35,7 +36,7 @@ class ResourceListingController extends CpController
         $query->with($resource->eagerLoadingRelations()->values()->all());
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
-            'collection' => $resourceHandle,
+            'resource' => $resourceHandle,
             'blueprints' => [
                 $blueprint,
             ],

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -8,7 +8,6 @@ use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
-use Statamic\Query\Scopes\Scope;
 
 class ResourceListingController extends CpController
 {

--- a/src/Query/Scopes/Filters/Fields.php
+++ b/src/Query/Scopes/Filters/Fields.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Query\Scopes\Filters;
+
+use DoubleThreeDigital\Runway\Runway;
+use Statamic\Query\Scopes\Filters\Fields as BaseFieldsFilter;
+
+class Fields extends BaseFieldsFilter
+{
+    public function visibleTo($key)
+    {
+        return $key === 'runway';
+    }
+
+    protected function getFields()
+    {
+        $resource = Runway::findResource($this->context['resource']);
+
+        return $resource->blueprint()->fields()->all()->filter->isFilterable();
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -39,6 +39,10 @@ class ServiceProvider extends AddonServiceProvider
         'cp' => __DIR__.'/../routes/cp.php',
     ];
 
+    protected $scopes = [
+        Query\Scopes\Filters\Fields::class,
+    ];
+
     protected $tags = [
         Tags\RunwayTag::class,
     ];


### PR DESCRIPTION
This pull request enables filtering on the Runway Listing Table. 

<img width="1021" alt="image" src="https://github.com/duncanmcclean/runway/assets/19637309/6ec11d30-bb93-4a45-9032-e05240e1798c">

By default, this allows you to filter by field values. However, you can create your own filters that are scoped to Runway resources like so:

```php
public function visibleTo($key)
{
   return $key === 'runway';
}
```