### PR TITLE
Fix bug in actions

### DIFF
--- a/src/Http/Controllers/ResourceActionController.php
+++ b/src/Http/Controllers/ResourceActionController.php
@@ -27,7 +27,7 @@ class ResourceActionController extends ActionController
     protected function getSelectedItems($items, $context)
     {
         return $items->map(function ($item) {
-            return $this->resource->find($item)->first();
+            return $this->resource->find($item);
         });
     }
 }


### PR DESCRIPTION
When using find()->first() it was getting the first resource by id, rather than the resource returned by find().

So in our delete action it was always deleting the first entry, not the one you actually had selected