### PR TITLE
Update version constraints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2]
-        laravel: [10.*]
+        php: [8.2, 8.1]
+        laravel: [10.*, 9.*]
         statamic: [^4.0]
-        testbench: [8.*]
+        testbench: [8.*, 7.*]
         os: [ubuntu-latest]
 
     name: ${{ matrix.php }} - ${{ matrix.statamic }} - ${{ matrix.laravel }}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.1 || ^8.2",
         "friendsofphp/php-cs-fixer": "^3.0",
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "statamic/cms": "^4.0"


### PR DESCRIPTION
This pull request updates Runway to bring back support for PHP 8.1 and Laravel 9 for sites where an upgrade isn't currently possible.