### PR TITLE
Allow for 'sort order' to be persisted on pivot tables

### DIFF
--- a/docs/fieldtypes.md
+++ b/docs/fieldtypes.md
@@ -32,6 +32,7 @@ Also when configuring the fieldtype, you should choose the resource you wish to 
 
 -   **Eager Loading:** Using the `with` configuration option, you may specify any relationships you want to be eager loaded when the fieldtype is augmented.
 -   **Title Format:** Using the `title_format` configuration option, you may specify a title format to be used when viewing related results in the CP. You should use Antlers in this setting. (eg. `{{ first_name }} {{ last_name }}`)
+* **Reorderable** & **Order Column:** If you want to persist the ordering models, you may enable `reorderable` and specify the column used for storing the sort order (`order_column`).
 
 ### Table Mode
 

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -125,6 +125,16 @@ class HasManyFieldtype extends BaseFieldtype
 
         // Many to many relation
         if ($relatedField instanceof BelongsToMany) {
+            // When Reordering is enabled, we need to change the format of the $data array. The key should
+            // be the foriegn key and the value should be pivot data (our sort order).
+            if ($this->config('reorderable') && $orderColumn = $this->config('order_column')) {
+                $data = collect($data)
+                    ->mapWithKeys(function ($relatedId, $index) use ($orderColumn) {
+                        return [$relatedId => [$orderColumn => $index]];
+                    })
+                    ->toArray();
+            }
+
             $record->{$this->field()->handle()}()->sync($data);
 
             return null;
@@ -156,7 +166,6 @@ class HasManyFieldtype extends BaseFieldtype
             collect($data)
                 ->each(function ($relatedId, $index) use ($relatedResource, $orderColumn) {
                     $model = $relatedResource->model()->find($relatedId);
-
                     if ($model->{$orderColumn} === $index) {
                         return;
                     }

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -321,19 +321,19 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertDatabaseHas('post_author', [
             'post_id' => $posts[1]->id,
             'author_id' => $author->id,
-            'pivot_sort_order' => 1,
+            'pivot_sort_order' => 0,
         ]);
 
         $this->assertDatabaseHas('post_author', [
             'post_id' => $posts[2]->id,
             'author_id' => $author->id,
-            'pivot_sort_order' => 2,
+            'pivot_sort_order' => 1,
         ]);
 
         $this->assertDatabaseHas('post_author', [
             'post_id' => $posts[0]->id,
             'author_id' => $author->id,
-            'pivot_sort_order' => 3,
+            'pivot_sort_order' => 2,
         ]);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -285,4 +285,9 @@ class Author extends Model
     {
         return $this->hasMany(Post::class);
     }
+
+    public function pivottedPosts()
+    {
+        return $this->belongsToMany(Post::class, 'post_author');
+    }
 }

--- a/tests/__fixtures__/database/migrations/2023_06_16_123456_create_post_author_table.php
+++ b/tests/__fixtures__/database/migrations/2023_06_16_123456_create_post_author_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostAuthorTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('post_author', function (Blueprint $table) {
+            $table->integer('post_id');
+            $table->integer('author_id');
+            $table->integer('pivot_sort_order')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('authors');
+    }
+}


### PR DESCRIPTION
In #259, you could configure a `order_column` which would be the column the sort order would be persisted to when saving a HasMany fieldtype.

However, this didn't cover the case where you might be using pivot tables with a Many to Many relationship. This pull request fixes that by implementing the re-orderable / sort column logic for relationships using pivot tables. 

Fixes #287.