### PR TITLE
Fix `BaseFieldtype@getIndexItems` method not respecting configured ordering

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -89,11 +89,8 @@ class BaseFieldtype extends Relationship
     {
         $resource = Runway::findResource($this->config('resource'));
 
-        $query = $resource->model();
-
-        if ($resource->orderBy() || $resource->orderByDirection()) {
-            $query->orderBy($resource->orderBy(), $resource->orderByDirection());
-        }
+        $query = $resource->model()
+            ->orderBy($resource->orderBy(), $resource->orderByDirection());
 
         if ($query->hasNamedScope('runwayListing')) {
             $query->runwayListing();

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -89,8 +89,11 @@ class BaseFieldtype extends Relationship
     {
         $resource = Runway::findResource($this->config('resource'));
 
-        $query = $resource->model()
-            ->orderBy($resource->primaryKey(), 'ASC');
+        $query = $resource->model();
+
+        if ($resource->orderBy() || $resource->orderByDirection()) {
+            $query->orderBy($resource->orderBy(), $resource->orderByDirection());
+        }
 
         if ($query->hasNamedScope('runwayListing')) {
             $query->runwayListing();

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -7,6 +7,7 @@ use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
 use Statamic\Fields\Field;
 use Statamic\Http\Requests\FilteredRequest;
 
@@ -74,6 +75,35 @@ class BelongsToFieldtypeTest extends TestCase
 
         $this->assertSame($getIndexItems->first()['title'], 'AUTHOR '.$authors[0]->name);
         $this->assertSame($getIndexItems->last()['title'], 'AUTHOR '.$authors[1]->name);
+    }
+
+    /** @test */
+    public function can_get_index_items_in_order_specified_in_runway_config()
+    {
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.order_by', 'name');
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.order_by_direction', 'desc');
+
+        $authorOne = $this->authorFactory(1, [
+            'name' => 'Scully',
+        ]);
+
+        $authorTwo = $this->authorFactory(1, [
+            'name' => 'Jake Peralta',
+        ]);
+
+        $authorThree = $this->authorFactory(1, [
+            'name' => 'Amy Santiago',
+        ]);
+
+        $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false]));
+
+        $this->assertIsObject($getIndexItems);
+        $this->assertTrue($getIndexItems instanceof Collection);
+        $this->assertSame($getIndexItems->count(), 3);
+
+        $this->assertSame($getIndexItems->all()[0]['title'], 'Scully');
+        $this->assertSame($getIndexItems->all()[1]['title'], 'Jake Peralta');
+        $this->assertSame($getIndexItems->all()[2]['title'], 'Amy Santiago');
     }
 
     /** @test */


### PR DESCRIPTION
This pull request fixes an issue where the `getIndexItems` method on the `BaseFieldtype` class wasn't using the [ordering config setting](https://runway.duncanmcclean.com/resources#content-ordering) from Runway's config file.

