### PR TITLE
[5.x] Fix `{{ url }}` in search results

### DIFF
--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -34,7 +34,20 @@ class AugmentedModel extends AbstractAugmented
     {
         return collect()
             ->merge($this->blueprintFields()->keys())
+            ->merge($this->commonKeys())
             ->unique()->sort()->values()->all();
+    }
+
+    private function commonKeys()
+    {
+        return [
+            'url',
+        ];
+    }
+
+    public function url(): ?string
+    {
+        return $this->resource->hasRouting() ? $this->data->uri() : null;
     }
 
     /**


### PR DESCRIPTION
This pull request fixes an issue where `{{ url }}` was not available when looping through search results. Fixes #314.