### PR TITLE
[5.x] Ensure appended attributes aren't returned in fields filter

### DIFF
--- a/src/Query/Scopes/Filters/Fields.php
+++ b/src/Query/Scopes/Filters/Fields.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\Runway\Query\Scopes\Filters;
 
 use DoubleThreeDigital\Runway\Runway;
+use Statamic\Fields\Field;
 use Statamic\Query\Scopes\Filters\Fields as BaseFieldsFilter;
 
 class Fields extends BaseFieldsFilter
@@ -18,7 +19,13 @@ class Fields extends BaseFieldsFilter
     {
         $resource = Runway::findResource($this->context['resource']);
 
-        return $resource->blueprint()->fields()->all()->filter->isFilterable();
+        return $resource->blueprint()->fields()->all()
+            ->filter->isFilterable()
+            ->reject(function (Field $field) use ($resource) {
+                return in_array($field->handle(), $resource->model()->getAppends(), true)
+                    && ! $resource->model()->hasSetMutator($field->handle())
+                    && ! $resource->model()->hasAttributeSetMutator($field->handle());
+            });
     }
 
     public function apply($query, $values)


### PR DESCRIPTION
This pull request fixes an issue where appended attributes would appear in the dropdown of Fields when using the "Fields" filter in the Control Panel.

Filtering by appended attributes won't work because they're not *real* columns in the database that can be queried (at least, most of the time!), so you'll receive an error. So, this PR will filter out any fields that use an appended attribute.

Fixes #316