### PR TITLE
[5.x] Fix blueprint error when publishing Eloquent Driver migrations

### DIFF
--- a/src/Routing/RoutingModel.php
+++ b/src/Routing/RoutingModel.php
@@ -10,7 +10,7 @@ use Statamic\Contracts\Data\Augmentable;
 use Statamic\Data\ContainsSupplementalData;
 use Statamic\Data\HasAugmentedData;
 
-class RoutingModel implements Responsable, Augmentable
+class RoutingModel implements Augmentable, Responsable
 {
     use ContainsSupplementalData, HasAugmentedData;
 

--- a/src/Search/Searchable.php
+++ b/src/Search/Searchable.php
@@ -14,9 +14,9 @@ use Statamic\Data\HasAugmentedInstance;
 use Statamic\Facades\Site;
 use Statamic\Search\Result as ResultInstance;
 
-class Searchable implements Contract, ContainsQueryableValues, Augmentable
+class Searchable implements Augmentable, ContainsQueryableValues, Contract
 {
-    use HasAugmentedInstance, ContainsSupplementalData;
+    use ContainsSupplementalData, HasAugmentedInstance;
 
     protected $model;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,7 +7,6 @@ use DoubleThreeDigital\Runway\Search\Provider as SearchProvider;
 use DoubleThreeDigital\Runway\Search\Searchable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Traits\Conditionable;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\GraphQL;
@@ -75,17 +74,7 @@ class ServiceProvider extends AddonServiceProvider
         ], 'runway-config');
 
         Statamic::booted(function () {
-            // We're try/catching this to cover cases where blueprints aren't available yet
-            // (eg. migrating to the Eloquent driver but haven't yet published the migrations)
-            try {
-                Runway::discoverResources();
-            } catch (\Exception $e) {
-                if (! $this->app->runningInConsole()) {
-                    throw $e;
-                }
-
-                Log::error($e->getMessage());
-            }
+            Runway::discoverResources();
 
             $this->registerPermissions();
             $this->registerPolicies();

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -12,7 +12,7 @@ use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 trait HasRunwayResource
 {
-    use HasAugmentedInstance, FluentlyGetsAndSets;
+    use FluentlyGetsAndSets, HasAugmentedInstance;
     use ResolvesValues {
         resolveGqlValue as traitResolveGqlValue;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -246,7 +246,7 @@ abstract class TestCase extends OrchestraTestCase
 
 class Post extends Model
 {
-    use RunwayRoutes, HasRunwayResource;
+    use HasRunwayResource, RunwayRoutes;
 
     protected $fillable = [
         'title', 'slug', 'body', 'values', 'author_id', 'sort_order',


### PR DESCRIPTION
This pull request fixes an issue when setting up the Eloquent Driver alongside Runway.

Essentially, when you're in the process of migrating to the Eloquent driver, you change the repositories, then run a vendor:publish command to publish the migrations.

However, when trying to publish the migrations (or run any other artisan commands for that matter), you'd see an error relating to blueprints. This was happening as Runway was trying to "discover" the resources from the configuration file, including looking up its blueprint.

This PR fixes the issue by catching any exceptions when finding blueprints, then ignoring the resource if the app is running in the console.

Fixes #319.