### PR TITLE
[5.x] Fix validation issues

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -91,6 +91,13 @@ class ResourceController extends CpController
 
     public function store(StoreRequest $request, $resourceHandle)
     {
+        Runway::findResource($resourceHandle)
+            ->blueprint()
+            ->fields()
+            ->addValues($request->all())
+            ->validator()
+            ->validate();
+
         $postCreatedHooks = [];
 
         $resource = Runway::findResource($resourceHandle);
@@ -247,6 +254,13 @@ class ResourceController extends CpController
     public function update(UpdateRequest $request, $resourceHandle, $record)
     {
         $resource = Runway::findResource($resourceHandle);
+
+        Runway::findResource($resourceHandle)
+            ->blueprint()
+            ->fields()
+            ->addValues($request->all())
+            ->validator()
+            ->validate();
 
         $record = $resource->model()
             ->where($resource->model()->qualifyColumn($resource->routeKey()), $record)

--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -18,13 +18,4 @@ class StoreRequest extends FormRequest
 
         return User::current()->can('create', $resource);
     }
-
-    public function rules()
-    {
-        return Runway::findResource($this->resourceHandle)
-            ->blueprint()
-            ->fields()
-            ->validator()
-            ->rules();
-    }
 }

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -18,13 +18,4 @@ class UpdateRequest extends FormRequest
 
         return User::current()->can('edit', $resource);
     }
-
-    public function rules()
-    {
-        return Runway::findResource($this->resourceHandle)
-            ->blueprint()
-            ->fields()
-            ->validator()
-            ->rules();
-    }
 }

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -187,6 +187,38 @@ class ResourceControllerTest extends TestCase
         ]);
     }
 
+    /**
+     * @test
+     * https://github.com/duncanmcclean/runway/issues/321
+     */
+    public function can_store_resource_and_ensure_date_comparison_validation_works()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $author = $this->authorFactory();
+
+        $this->actingAs($user)
+            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+                'title' => 'Jingle Bells',
+                'slug' => 'jingle-bells',
+                'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
+                'author_id' => [$author->id],
+                'start_date' => [
+                    'date' => '2023-09-01',
+                    'time' => '00:00',
+                ],
+                'end_date' => [
+                    'date' => '2023-08-01',
+                    'time' => '00:00',
+                ],
+            ])
+            ->assertSessionHasErrors('start_date');
+
+        $this->assertDatabaseMissing('posts', [
+            'title' => 'Jingle Bells',
+        ]);
+    }
+
     /** @test */
     public function can_edit_resource()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -156,6 +156,23 @@ abstract class TestCase extends OrchestraTestCase
                                             'visibility' => 'computed',
                                         ],
                                     ],
+                                    [
+                                        'handle' => 'start_date',
+                                        'field' => [
+                                            'type' => 'date',
+                                            'time_enabled' => true,
+                                            'validate' => [
+                                                'before:end_date',
+                                            ],
+                                        ],
+                                    ],
+                                    [
+                                        'handle' => 'end_date',
+                                        'field' => [
+                                            'type' => 'date',
+                                            'time_enabled' => true,
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],
@@ -288,7 +305,7 @@ class Author extends Model
     use HasRunwayResource;
 
     protected $fillable = [
-        'name',
+        'name', 'start_date', 'end_date',
     ];
 
     public function posts()

--- a/tests/__fixtures__/database/migrations/2020_12_12_220453_create_posts_table.php
+++ b/tests/__fixtures__/database/migrations/2020_12_12_220453_create_posts_table.php
@@ -21,6 +21,8 @@ class CreatePostsTable extends Migration
             $table->json('values')->nullable();
             $table->integer('author_id');
             $table->integer('sort_order')->nullable();
+            $table->datetime('start_date')->nullable();
+            $table->datetime('end_date')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/__fixtures__/database/migrations/2023_06_16_123456_create_post_author_table.php
+++ b/tests/__fixtures__/database/migrations/2023_06_16_123456_create_post_author_table.php
@@ -17,8 +17,6 @@ class CreatePostAuthorTable extends Migration
             $table->integer('post_id');
             $table->integer('author_id');
             $table->integer('pivot_sort_order')->nullable();
-            $table->datetime('start_date')->nullable();
-            $table->datetime('end_date')->nullable();
         });
     }
 

--- a/tests/__fixtures__/database/migrations/2023_06_16_123456_create_post_author_table.php
+++ b/tests/__fixtures__/database/migrations/2023_06_16_123456_create_post_author_table.php
@@ -17,6 +17,8 @@ class CreatePostAuthorTable extends Migration
             $table->integer('post_id');
             $table->integer('author_id');
             $table->integer('pivot_sort_order')->nullable();
+            $table->datetime('start_date')->nullable();
+            $table->datetime('end_date')->nullable();
         });
     }
 


### PR DESCRIPTION
This pull request fixes a few validation issues pointed out in #321. A few examples of broken validation logic:

* A validation error wasn't being thrown when using the `before:date_field` validation rule. Now it is!
    * Although, I have noticed this validation rule seems to be thrown even when the first date field *is* before the other one. I can replicate on entries so it's a Core issue, not a Runway one.
* Validation errors weren't being thrown for fields inside Bards/Replicators/Grids, now they will be!

Closes #321.