### PR TITLE
[5.x] Generate migrations using anonymous class syntax

### DIFF
--- a/src/Console/Commands/GenerateMigration.php
+++ b/src/Console/Commands/GenerateMigration.php
@@ -331,7 +331,7 @@ class GenerateMigration extends Command
 
         $rules = '@PSR2,@PhpCsFixer,no_space_after_class_name';
 
-        $process = new Process(['./vendor/bin/php-cs-fixer', 'fix', $migrationPath, '--rules=' . $rules], base_path());
+        $process = new Process(['./vendor/bin/php-cs-fixer', 'fix', $migrationPath, '--rules='.$rules], base_path());
         $process->run();
     }
 }

--- a/src/Console/Commands/GenerateMigration.php
+++ b/src/Console/Commands/GenerateMigration.php
@@ -320,7 +320,6 @@ class GenerateMigration extends Command
             ->join(PHP_EOL);
 
         $migrationContents = Str::of($migrationContents)
-            ->replace('{{ClassName}}', 'Create'.Str::title($resource->databaseTable()).'Table')
             ->replace('{{TableName}}', $resource->databaseTable())
             ->replace('{{TableColumns}}', $columnCode)
             ->__toString();
@@ -330,7 +329,9 @@ class GenerateMigration extends Command
             $migrationContents
         );
 
-        $process = new Process(['./vendor/bin/php-cs-fixer', 'fix', $migrationPath, '--rules=@PSR2,@PhpCsFixer'], base_path());
+        $rules = '@PSR2,@PhpCsFixer,no_space_after_class_name';
+
+        $process = new Process(['./vendor/bin/php-cs-fixer', 'fix', $migrationPath, '--rules=' . $rules], base_path());
         $process->run();
     }
 }

--- a/src/Console/Commands/stubs/create_table_migration.php.stub
+++ b/src/Console/Commands/stubs/create_table_migration.php.stub
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
-class {{ClassName}} extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -27,4 +27,4 @@ class {{ClassName}} extends Migration
      {
          Schema::dropIfExists('{{TableName}}');
      }
-}
+};

--- a/tests/Console/Commands/GenerateMigrationTest.php
+++ b/tests/Console/Commands/GenerateMigrationTest.php
@@ -36,7 +36,7 @@ class GenerateMigrationTest extends TestCase
     /** @test */
     public function can_generate_migrations_for_multiple_resources()
     {
-        //
+        $this->markTestIncomplete();
     }
 
     /** @test */
@@ -89,6 +89,9 @@ class GenerateMigrationTest extends TestCase
             $expectedMigrationPath = database_path().'/migrations/'.date('Y_m_d_His').'_create_foods_table.php'
         );
 
+        // Assert migration is using the anonymous class syntax
+        $this->assertStringContainsString('return new class extends Migration', File::get($expectedMigrationPath));
+
         // Assert migration contains the right fields
         $this->assertStringContainsString('$table->text(\'name\')', File::get($expectedMigrationPath));
         $this->assertStringContainsString('$table->json(\'metadata\')', File::get($expectedMigrationPath));
@@ -103,37 +106,37 @@ class GenerateMigrationTest extends TestCase
     /** @test */
     public function can_generate_migration_where_table_already_exists()
     {
-        //
+        $this->markTestIncomplete();
     }
 
     /** @test */
     public function can_generate_migration_and_run_them_afterwards()
     {
-        //
+        $this->markTestIncomplete();
     }
 
     /** @test */
     public function can_generate_migration_and_ensure_normal_field_is_correct()
     {
-        //
+        $this->markTestIncomplete();
     }
 
     /** @test */
     public function can_generate_migration_and_ensure_max_items_1_field_is_correct()
     {
-        //
+        $this->markTestIncomplete();
     }
 
     /** @test */
     public function can_generate_migration_and_ensure_field_is_nullable_if_required_not_set()
     {
-        //
+        $this->markTestIncomplete();
     }
 
     /** @test */
     public function can_generate_migration_and_ensure_field_is_not_nullable_if_required_set()
     {
-        //
+        $this->markTestIncomplete();
     }
 }
 


### PR DESCRIPTION
This pull request updates the `runway:generate-migrations` command to generate migrations using the anonymous class syntax that was introduced in [Laravel 8.37](https://laravel-news.com/laravel-anonymous-migrations).

Addresses #329