### PR TITLE
[5.x] Don't run migrations if the user said not to

### DIFF
--- a/src/Console/Commands/GenerateMigration.php
+++ b/src/Console/Commands/GenerateMigration.php
@@ -201,7 +201,7 @@ class GenerateMigration extends Command
             $this->generateForResource($resource);
         }
 
-        if ($this->ask('Should we run your migrations?')) {
+        if ($this->ask('Should we run your migrations?') === 'yes') {
             Artisan::call('migrate');
         }
 


### PR DESCRIPTION
This pull request fixes an issue where Runway would try to run the migrations, even if the user said they didn't want to run them.

Fixes #328