### PR TITLE
[5.x] Add TODO in migration for columns that can't be mapped

### DIFF
--- a/src/Console/Commands/GenerateMigration.php
+++ b/src/Console/Commands/GenerateMigration.php
@@ -242,7 +242,7 @@ class GenerateMigration extends Command
             ->unique('name')
             ->each(function ($column) use (&$errorMessages) {
                 if (is_null($column['type'])) {
-                    $errorMessages[] = "Field [{$column['name']}] could not be matched with a column type.";
+                    $errorMessages[] = "Field [{$column['name']}] could not be matched with a column type. Runway has left a TODO in the migration for you to complete manually.";
                 }
             })
             ->all();
@@ -299,6 +299,10 @@ class GenerateMigration extends Command
 
         $columnCode = collect($columns)
             ->map(function ($column) {
+                if (is_null($column['type'])) {
+                    return "// TODO: Implement `{$column['name']}` field.";
+                }
+
                 $code = '$table->'.$column['type'].'(\''.$column['name'].'\')';
 
                 if ($column['nullable']) {


### PR DESCRIPTION
This pull request fixes an issue when trying to generate a migration, based on a blueprint with a custom fieldtype. Runway would previously generate code like this:

```php
$table->('generate_profile');
```

This was happening as Runway didn't know how to map the fieldtype to a database column type. When this happens now, Runway will add a TODO to the migration.

```php
// TODO: Implement `generate_profile` field.
```

Fixes #327