### PR TITLE
[5.x] Don’t save fields with `save` set to false

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -106,6 +106,10 @@ class ResourceController extends CpController
         foreach ($resource->blueprint()->fields()->all() as $fieldKey => $field) {
             $processedValue = $field->fieldtype()->process($request->get($fieldKey));
 
+            if (! $this->shouldSaveField($field)) {
+                continue;
+            }
+
             // Skip section fields or computed fields as there's nothing to store.
             if ($field->type() === 'section' || $field->visibility() === 'computed') {
                 continue;
@@ -269,6 +273,10 @@ class ResourceController extends CpController
         foreach ($resource->blueprint()->fields()->all() as $fieldKey => $field) {
             $processedValue = $field->fieldtype()->process($request->get($fieldKey));
 
+            if (! $this->shouldSaveField($field)) {
+                continue;
+            }
+
             // Skip section, HasMany and computed fields as there's nothing to store.
             if ($field->type() === 'section' || $field->type() === 'has_many' || $field->visibility() === 'computed') {
                 continue;
@@ -364,5 +372,16 @@ class ResourceController extends CpController
         }
 
         return $resource->titleField();
+    }
+
+    private function shouldSaveField(Field $field): bool
+    {
+        $config = $field->config();
+
+        if (isset($config['save']) && $config['save'] === false) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -110,11 +110,6 @@ class ResourceController extends CpController
                 continue;
             }
 
-            // Skip section fields or computed fields as there's nothing to store.
-            if ($field->type() === 'section' || $field->visibility() === 'computed') {
-                continue;
-            }
-
             // Skip if the field exists in the model's $appends array and there's not a set mutator present for it on the model.
             if (in_array($fieldKey, $record->getAppends(), true) && ! $record->hasSetMutator($fieldKey) && ! $record->hasAttributeSetMutator($fieldKey)) {
                 continue;
@@ -277,8 +272,7 @@ class ResourceController extends CpController
                 continue;
             }
 
-            // Skip section, HasMany and computed fields as there's nothing to store.
-            if ($field->type() === 'section' || $field->type() === 'has_many' || $field->visibility() === 'computed') {
+            if ($field->type() === 'has_many') {
                 continue;
             }
 
@@ -377,6 +371,14 @@ class ResourceController extends CpController
     protected function shouldSaveField(Field $field): bool
     {
         $config = $field->config();
+
+        if ($field->type() === 'section') {
+            return false;
+        }
+
+        if ($field->visibility() === 'computed') {
+            return false;
+        }
 
         if (isset($config['save']) && $config['save'] === false) {
             return false;

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -374,7 +374,7 @@ class ResourceController extends CpController
         return $resource->titleField();
     }
 
-    private function shouldSaveField(Field $field): bool
+    protected function shouldSaveField(Field $field): bool
     {
         $config = $field->config();
 

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -133,6 +133,34 @@ class ResourceControllerTest extends TestCase
 
     /**
      * @test
+     * https://github.com/duncanmcclean/runway/issues/331
+     */
+    public function can_store_resource_and_ensure_field_isnt_saved_to_database()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $author = $this->authorFactory();
+
+        $this->actingAs($user)
+            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+                'title' => 'Jingle Bells',
+                'slug' => 'jingle-bells',
+                'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
+                'author_id' => [$author->id],
+                'dont_save' => 25,
+            ])
+            ->assertOk()
+            ->assertJsonStructure([
+                'redirect',
+            ]);
+
+        $this->assertDatabaseHas('posts', [
+            'title' => 'Jingle Bells',
+        ]);
+    }
+
+    /**
+     * @test
      * https://github.com/duncanmcclean/runway/pull/247
      */
     public function can_store_resource_and_ensure_appended_attribute_doesnt_attempt_to_get_saved()
@@ -497,6 +525,34 @@ class ResourceControllerTest extends TestCase
                 'body' => $post->body,
                 'author_id' => [$post->author_id],
                 'age' => 19, // This is the computed field
+            ])
+            ->assertOk()
+            ->assertJsonStructure([
+                'data',
+            ]);
+
+        $post->refresh();
+
+        $this->assertSame($post->title, 'Santa is coming home');
+    }
+
+    /**
+     *  @test
+     * https://github.com/duncanmcclean/runway/issues/331
+     */
+    public function can_update_resource_and_ensure__field_isnt_saved_to_database()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $post = $this->postFactory();
+
+        $this->actingAs($user)
+            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+                'title' => 'Santa is coming home',
+                'slug' => 'santa-is-coming-home',
+                'body' => $post->body,
+                'author_id' => [$post->author_id],
+                'dont_save' => 19,
             ])
             ->assertOk()
             ->assertJsonStructure([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -173,6 +173,13 @@ abstract class TestCase extends OrchestraTestCase
                                             'time_enabled' => true,
                                         ],
                                     ],
+                                    [
+                                        'handle' => 'dont_save',
+                                        'field' => [
+                                            'type' => 'text',
+                                            'save' => false,
+                                        ],
+                                    ],
                                 ],
                             ],
                         ],


### PR DESCRIPTION
Closes #331 

Not sure where to put the new docs stuff, as the existing `fieldtypes.md` is all about the relationship stuff.

I can put it in there, or do you have another suggestion?

Note that the field we're using is `save` so that it's a positive and not negative one, but the code check to make sure it's actually defined so that it's backwards compatible.