### PR TITLE
[5.x] Add config options for singular/plurals

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -103,12 +103,12 @@ class Resource
 
     public function singular(): string
     {
-        return Str::singular($this->name);
+        return $this->config()->get('singular') ?? Str::singular($this->name);
     }
 
     public function plural(): string
     {
-        return Str::plural($this->name);
+        return $this->config()->get('plural') ?? Str::plural($this->name);
     }
 
     public function blueprint()

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -71,4 +71,56 @@ class ResourceTest extends TestCase
         $this->assertContains('author', $eagerLoadingRelations->toArray());
         $this->assertNotContains('runwayUri', $eagerLoadingRelations->toArray());
     }
+
+    /** @test */
+    public function can_get_generated_singular()
+    {
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $singular = $resource->singular();
+
+        $this->assertSame($singular, 'Post');
+    }
+
+    /** @test */
+    public function can_get_configured_singular()
+    {
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.singular', 'Bibliothek');
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $singular = $resource->singular();
+
+        $this->assertSame($singular, 'Bibliothek');
+    }
+
+    /** @test */
+    public function can_get_generated_plural()
+    {
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $plural = $resource->plural();
+
+        $this->assertSame($plural, 'Posts');
+    }
+
+    /** @test */
+    public function can_get_configured_plural()
+    {
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.plural', 'Bibliotheken');
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $plural = $resource->plural();
+
+        $this->assertSame($plural, 'Bibliotheken');
+    }
 }


### PR DESCRIPTION
This pull request adds two configuration options for `singular` & `plural` for those who want to override Laravel's generated singular/plural output of words.