### PR TITLE
[5.x] Throw 404 when record does not exist

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -13,6 +13,7 @@ use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Support\Json;
 use Statamic\CP\Breadcrumbs;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Scope;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;
@@ -169,6 +170,10 @@ class ResourceController extends CpController
         $record = $resource->model()
             ->where($resource->model()->qualifyColumn($resource->routeKey()), $record)
             ->first();
+
+        if (! $record) {
+            throw new NotFoundHttpException();
+        }
 
         $values = [];
         $blueprintFieldKeys = $resource->blueprint()->fields()->all()->keys()->toArray();

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -234,6 +234,17 @@ class ResourceControllerTest extends TestCase
     }
 
     /** @test */
+    public function cant_edit_resource_when_it_does_not_exist()
+    {
+        $user = User::make()->makeSuper()->save();
+
+        $this->actingAs($user)
+            ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => 12345]))
+            ->assertNotFound()
+            ->assertSee('Page Not Found');
+    }
+
+    /** @test */
     public function can_edit_resource_with_simple_date_field()
     {
         $fields = Config::get('runway.resources.'.Post::class.'.blueprint.sections.main.fields');


### PR DESCRIPTION
This pull request fixes an issue where Runway would just error out when you went to the edit page of a record that doesn't exist.

