### PR TITLE
[5.x] Ensure query parameters are retained in pagination links

### DIFF
--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -92,7 +92,7 @@ class RunwayTag extends Tags
         }
 
         if ($this->params->get('paginate') || $this->params->get('limit')) {
-            $paginator = $query->paginate($this->params->get('limit'))->withQueryString();
+            $paginator = $query->paginate($this->params->get('limit'));
 
             $paginator = app()->makeWith(LengthAwarePaginator::class, [
                 'items' => $paginator->items(),
@@ -100,7 +100,7 @@ class RunwayTag extends Tags
                 'perPage' => $paginator->perPage(),
                 'currentPage' => $paginator->currentPage(),
                 'options' => $paginator->getOptions(),
-            ]);
+            ])->withQueryString();
 
             $results = $paginator->items();
         } else {


### PR DESCRIPTION
This pull request fixes the issue that #350 previously tried to fix, where query parameters weren't being retained in the pagination links. 

I just needed to move the `->withQueryString()` method to the other paginator which seemed to do the trick.

Closes #349.