### PR TITLE
[5.x] Show listing table instead of old empty state

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -20,19 +20,11 @@
         @endif
     </div>
 
-    @if ($recordCount > 0)
-        <runway-listing
-            :filters="{{ $filters->toJson() }}"
-            :listing-config='@json($listingConfig)'
-            :initial-columns='@json($columns)'
-            action-url="{{ $actionUrl }}"
-            initial-primary-column="{{ $primaryColumn }}"
-        ></runway-listing>
-     @else
-        @include('statamic::partials.create-first', [
-            'resource' => $resource->singular(),
-            'svg' => 'empty/collection',
-            'route' => cp_route('runway.create', ['resourceHandle' => $resource->handle()]),
-        ])
-     @endif
+    <runway-listing
+        :filters="{{ $filters->toJson() }}"
+        :listing-config='@json($listingConfig)'
+        :initial-columns='@json($columns)'
+        action-url="{{ $actionUrl }}"
+        initial-primary-column="{{ $primaryColumn }}"
+    ></runway-listing>
 @endsection


### PR DESCRIPTION
This pull request changes the empty state for the resource index table: an empty listing table will show instead an old empty state.

I only realised the empty state was old after seeing statamic/cms#8787 pop up.