### PR TITLE
[6.x] REST API support

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,0 +1,58 @@
+---
+title: REST API
+---
+
+Statamic comes with a read-only API that allows you to deliver content from Statamic to your frontend, external apps, SPA, or any other desired location. Content is delivered RESTfully as JSON data.
+
+Runway includes support for Statamic's Content API, which enables you to access your Eloquent models.
+
+If you prefer, Runway also supports [GraphQL](/graphql).
+
+## Enabling for resources
+
+If you haven't already done so, you'll need to enable Statamic's REST API. You can do this by adding the following line to your `.env` file:
+
+```
+STATAMIC_API_ENABLED=true
+```
+
+Alternatively, you can enable it for all environments in `config/statamic/api.php`:
+
+```php
+'enabled' => true,
+```
+
+Next, you'll need to enable the resources you want to make available. To do this, simply add a `runway` key to your `resources` array in `config/statamic/api.php`, and provide the handles of the resources for which you wish to enable the API:
+
+```php
+'resources' => [
+    'collections' => true,
+    // ...
+    'runway' => [
+        'product' => true,
+    ],
+],
+```
+
+## Endpoints
+
+Each resource will have two endpoints:
+
+* `/api/runway/{resourceHandle}` for retrieving models associated with a resource.
+* `/api/runway/{resourceHandle}/{id}` for retrieving a specific model.
+
+## Filtering
+
+To enable filtering for your resources, you'll need to opt in by defining a list of `allowed_filters` for each resource in your `config/statamic/api.php` configuration file:
+
+```php
+'runway' => [
+    'product' => [
+        'allowed_filters' => ['name', 'slug'],
+    ],
+],
+```
+
+## More Information
+
+For more information on Statamic's REST API functionality, please refer to the [Statamic Documentation](https://statamic.dev/rest-api#entries).

--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use Statamic\Data\AbstractAugmented;
 use Statamic\Fields\Field;
 use Statamic\Fields\Value;
+use Statamic\Statamic;
 
 class AugmentedModel extends AbstractAugmented
 {
@@ -58,6 +59,15 @@ class AugmentedModel extends AbstractAugmented
         return $this->resource->hasRouting()
             ? $this->data->uri()
             : null;
+    }
+
+    public function apiUrl()
+    {
+        if (! $id = $this->data->{$this->resource->primaryKey()}) {
+            return null;
+        }
+
+        return Statamic::apiRoute('runway.show', [$this->resource->handle(), $id]);
     }
 
     protected function modelAttributes(): Collection

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -6,6 +6,7 @@ use DoubleThreeDigital\Runway\Http\Resources\ApiResource;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
 use Facades\Statamic\API\FilterAuthorizer;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Http\Controllers\API\ApiController as StatamicApiController;
@@ -67,8 +68,8 @@ class ApiController extends StatamicApiController
         return FilterAuthorizer::allowedForSubResources('api', $this->resourceConfigKey, Str::plural($this->resourceHandle));
     }
 
-    private function getFieldsFromBlueprint(Resource $resource): array
+    private function getFieldsFromBlueprint(Resource $resource): Collection
     {
-        return $resource->blueprint()->fields()->all()->map->handle()->all();
+        return $resource->blueprint()->fields()->all();
     }
 }

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -16,15 +16,15 @@ class ApiController extends StatamicApiController
 
     protected $resourceConfigKey = 'runway';
 
-    protected $routeResourceKey = 'handle';
+    protected $routeResourceKey = 'resourceHandle';
 
     protected $resourceHandle;
 
-    public function index($handle)
+    public function index($resourceHandle)
     {
         $this->abortIfDisabled();
 
-        $this->resourceHandle = Str::singular($handle);
+        $this->resourceHandle = Str::singular($resourceHandle);
 
         $resource = Runway::findResource($this->resourceHandle);
 
@@ -37,18 +37,17 @@ class ApiController extends StatamicApiController
         $results = ApiResource::collection($results);
 
         $results->setCollection(
-            $results->getCollection()
-                ->transform(fn ($result) => $result->withBlueprintFields($this->getFieldsFromBlueprint($resource)))
+            $results->getCollection()->transform(fn ($result) => $result->withBlueprintFields($this->getFieldsFromBlueprint($resource)))
         );
 
         return $results;
     }
 
-    public function show($handle, $id)
+    public function show($resourceHandle, $record)
     {
         $this->abortIfDisabled();
 
-        $this->resourceHandle = Str::singular($handle);
+        $this->resourceHandle = Str::singular($resourceHandle);
 
         $resource = Runway::findResource($this->resourceHandle);
 
@@ -56,7 +55,7 @@ class ApiController extends StatamicApiController
             throw new NotFoundHttpException;
         }
 
-        if (! $model = $resource->model()->find($id)) {
+        if (! $model = $resource->model()->find($record)) {
             throw new NotFoundHttpException;
         }
 

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -8,9 +8,9 @@ use DoubleThreeDigital\Runway\Runway;
 use Facades\Statamic\API\FilterAuthorizer;
 use Illuminate\Support\Str;
 use Statamic\Exceptions\NotFoundHttpException;
-use Statamic\Http\Controllers\API\ApiController;
+use Statamic\Http\Controllers\API\ApiController as StatamicApiController;
 
-class RestApiController extends ApiController
+class ApiController extends StatamicApiController
 {
     private $config;
 

--- a/src/Http/Controllers/RestApiController.php
+++ b/src/Http/Controllers/RestApiController.php
@@ -16,7 +16,7 @@ class RestApiController extends ApiController
 
     protected $resourceConfigKey = 'runway';
 
-    protected $routeResourceKey = 'resource';
+    protected $routeResourceKey = 'handle';
 
     protected $resourceHandle;
 

--- a/src/Http/Controllers/RestApiController.php
+++ b/src/Http/Controllers/RestApiController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Http\Controllers;
+
+use DoubleThreeDigital\Runway\Http\Resources\ApiResource;
+use DoubleThreeDigital\Runway\Resource;
+use DoubleThreeDigital\Runway\Runway;
+use Facades\Statamic\API\FilterAuthorizer;
+use Illuminate\Support\Str;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Http\Controllers\API\ApiController;
+
+class RestApiController extends ApiController
+{
+    private $config;
+    protected $resourceConfigKey = 'runway';
+    protected $routeResourceKey = 'resource';
+    protected $resourceHandle;
+
+    public function index($resource)
+    {
+        $this->abortIfDisabled();
+        
+        $this->resourceHandle = $resource;
+
+        $resource = Runway::findResource($resource);
+            
+        if (! $resource) {
+            throw new NotFoundHttpException;
+        }
+        
+        $results = $this->filterSortAndPaginate($resource->model()->query());
+        $results->setCollection($results->getCollection()->map(fn ($model) => $this->makeResourceFromModel($resource, $model)));
+        
+        return ApiResource::collection($results);
+    }
+
+    public function show($resource, $id)
+    {
+        $this->abortIfDisabled();
+        
+        $this->resourceHandle = $resource;
+        
+        $resource = Runway::findResource($resource);
+            
+        if (! $resource) {
+            throw new NotFoundHttpException;
+        }
+        
+        if (! $model = $resource->model()->find($id)) {
+            throw new NotFoundHttpException;
+        }
+        
+        return ApiResource::make($this->makeResourceFromModel($resource, $model));
+    }
+
+    protected function allowedFilters()
+    {
+        return FilterAuthorizer::allowedForSubResources('api', $this->resourceConfigKey, $this->resourceHandle);
+    }
+    
+    private function makeResourceFromModel($resource, $model)
+    {
+        if (! $this->config) {
+            $this->config = collect(config('runway.resources'))->get(get_class($model));
+        }
+
+        return new Resource(
+            handle: $this->resourceHandle,
+            model: $model,
+            name: $this->config['name'] ?? Str::title($this->resourceHandle),
+            blueprint: $resource->blueprint(),
+            config: $this->config ?? [],
+        );
+    }
+}

--- a/src/Http/Controllers/RestApiController.php
+++ b/src/Http/Controllers/RestApiController.php
@@ -13,44 +13,47 @@ use Statamic\Http\Controllers\API\ApiController;
 class RestApiController extends ApiController
 {
     private $config;
+
     protected $resourceConfigKey = 'runway';
+
     protected $routeResourceKey = 'resource';
+
     protected $resourceHandle;
 
     public function index($resource)
     {
         $this->abortIfDisabled();
-        
+
         $this->resourceHandle = $resource;
 
         $resource = Runway::findResource($resource);
-            
+
         if (! $resource) {
             throw new NotFoundHttpException;
         }
-        
+
         $results = $this->filterSortAndPaginate($resource->model()->query());
         $results->setCollection($results->getCollection()->map(fn ($model) => $this->makeResourceFromModel($resource, $model)));
-        
+
         return ApiResource::collection($results);
     }
 
     public function show($resource, $id)
     {
         $this->abortIfDisabled();
-        
+
         $this->resourceHandle = $resource;
-        
+
         $resource = Runway::findResource($resource);
-            
+
         if (! $resource) {
             throw new NotFoundHttpException;
         }
-        
+
         if (! $model = $resource->model()->find($id)) {
             throw new NotFoundHttpException;
         }
-        
+
         return ApiResource::make($this->makeResourceFromModel($resource, $model));
     }
 
@@ -58,7 +61,7 @@ class RestApiController extends ApiController
     {
         return FilterAuthorizer::allowedForSubResources('api', $this->resourceConfigKey, $this->resourceHandle);
     }
-    
+
     private function makeResourceFromModel($resource, $model)
     {
         if (! $this->config) {

--- a/src/Http/Controllers/RestApiController.php
+++ b/src/Http/Controllers/RestApiController.php
@@ -24,9 +24,9 @@ class RestApiController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $this->resourceHandle = $resource;
+        $this->resourceHandle = Str::singular($resource);
 
-        $resource = Runway::findResource($resource);
+        $resource = Runway::findResource($this->resourceHandle);
 
         if (! $resource) {
             throw new NotFoundHttpException;
@@ -42,9 +42,9 @@ class RestApiController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $this->resourceHandle = $resource;
+        $this->resourceHandle = Str::singular($resource);
 
-        $resource = Runway::findResource($resource);
+        $resource = Runway::findResource($this->resourceHandle);
 
         if (! $resource) {
             throw new NotFoundHttpException;

--- a/src/Http/Controllers/RestApiController.php
+++ b/src/Http/Controllers/RestApiController.php
@@ -20,11 +20,11 @@ class RestApiController extends ApiController
 
     protected $resourceHandle;
 
-    public function index($resource)
+    public function index($handle)
     {
         $this->abortIfDisabled();
 
-        $this->resourceHandle = Str::singular($resource);
+        $this->resourceHandle = Str::singular($handle);
 
         $resource = Runway::findResource($this->resourceHandle);
 
@@ -38,11 +38,11 @@ class RestApiController extends ApiController
         return ApiResource::collection($results);
     }
 
-    public function show($resource, $id)
+    public function show($handle, $id)
     {
         $this->abortIfDisabled();
 
-        $this->resourceHandle = Str::singular($resource);
+        $this->resourceHandle = Str::singular($handle);
 
         $resource = Runway::findResource($this->resourceHandle);
 
@@ -73,7 +73,7 @@ class RestApiController extends ApiController
             model: $model,
             name: $this->config['name'] ?? Str::title($this->resourceHandle),
             blueprint: $resource->blueprint(),
-            config: $this->config ?? [],
+            config: collect($this->config ?? []),
         );
     }
 }

--- a/src/Http/Controllers/RestApiController.php
+++ b/src/Http/Controllers/RestApiController.php
@@ -59,7 +59,7 @@ class RestApiController extends ApiController
 
     protected function allowedFilters()
     {
-        return FilterAuthorizer::allowedForSubResources('api', $this->resourceConfigKey, $this->resourceHandle);
+        return FilterAuthorizer::allowedForSubResources('api', $this->resourceConfigKey, Str::plural($this->resourceHandle));
     }
 
     private function makeResourceFromModel($resource, $model)

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\Runway\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Str;
 
 class ApiResource extends JsonResource
 {
@@ -25,6 +26,13 @@ class ApiResource extends JsonResource
             ->withRelations($with)
             ->withShallowNesting()
             ->toArray();
+
+        collect($augmentedArray)
+            ->filter(fn ($value, $key) => Str::contains($key, '->'))
+            ->each(function ($value, $key) use (&$augmentedArray) {
+                $augmentedArray[Str::before($key, '->')][Str::after($key, '->')] = $value;
+                unset($augmentedArray[$key]);
+            });
 
         return array_merge($augmentedArray, [
             $this->resource->getKeyName() => $this->resource->getKey(),

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -16,14 +16,14 @@ class ApiResource extends JsonResource
      */
     public function toArray($request)
     {
-        // this gets around augmented model wrapValue() returning handles 
+        // this gets around augmented model wrapValue() returning handles
         // like meta->title instead of a nested array
         // if that ever changes this could be removed
         $augmentedArray = collect($this->resource->toAugmentedArray($this->blueprintFields))
             ->mapWithKeys(fn ($item, $key) => [str_replace('->', '.', $key) => $item])
             ->undot()
             ->all();
-        
+
         return array_merge([
             $this->resource->getKeyName() => $this->resource->getKey(),
         ], $augmentedArray

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -3,11 +3,12 @@
 namespace DoubleThreeDigital\Runway\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class ApiResource extends JsonResource
 {
-    public $blueprintFields = [];
+    public $blueprintFields;
 
     /**
      * Transform the resource into an array.
@@ -17,13 +18,9 @@ class ApiResource extends JsonResource
      */
     public function toArray($request)
     {
-        $with = $this->resource->runwayResource()->blueprint()
-            ->fields()->all()
-            ->filter->isRelationship()->keys()->all();
-
         $augmentedArray = $this->resource
-            ->toAugmentedCollection($this->blueprintFields ?? [])
-            ->withRelations($with)
+            ->toAugmentedCollection($this->blueprintFields->map->handle()->all() ?? [])
+            ->withRelations($this->blueprintFields->filter->isRelationship()->keys()->all())
             ->withShallowNesting()
             ->toArray();
 
@@ -44,7 +41,7 @@ class ApiResource extends JsonResource
      *
      * @return self
      */
-    public function withBlueprintFields(array $fields)
+    public function withBlueprintFields(Collection $fields)
     {
         $this->blueprintFields = $fields;
 

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -14,10 +14,12 @@ class ApiResource extends JsonResource
      */
     public function toArray($request)
     {
+        $fields = $this->resource->blueprint()->fields()->all()->map->handle()->all();
+        
         return array_merge([
             $this->resource->primaryKey() => $this->resource->model()->getKey(),
         ], $this->resource
-            ->toAugmentedCollection()
+            ->toAugmentedCollection($fields)
             ->withShallowNesting()
             ->toArray()
         );

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -14,9 +14,12 @@ class ApiResource extends JsonResource
      */
     public function toArray($request)
     {
-        return $this->resource
-            ->toAugmentedCollection()
-            ->withShallowNesting()
-            ->toArray();
+        return array_merge([
+                $this->resource->primaryKey() => $this->resource->model()->getKey(),   
+            ], $this->resource
+                ->toAugmentedCollection()
+                ->withShallowNesting()
+                ->toArray()
+            );
     }
 }

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class ApiResource extends JsonResource
 {
+    public $blueprintFields = [];
+
     /**
      * Transform the resource into an array.
      *
@@ -14,14 +16,24 @@ class ApiResource extends JsonResource
      */
     public function toArray($request)
     {
-        $fields = $this->resource->blueprint()->fields()->all()->map->handle()->all();
-
         return array_merge([
-            $this->resource->primaryKey() => $this->resource->model()->getKey(),
+            $this->resource->getKeyName() => $this->resource->getKey(),
         ], $this->resource
-            ->toAugmentedCollection($fields)
+            ->toAugmentedCollection($this->blueprintFields ?? [])
             ->withShallowNesting()
             ->toArray()
         );
+    }
+
+    /**
+     * Set the fields that should be returned by this resource
+     *
+     * @return self
+     */
+    public function withBlueprintFields(array $fields)
+    {
+        $this->blueprintFields = $fields;
+
+        return $this;
     }
 }

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -16,10 +16,17 @@ class ApiResource extends JsonResource
      */
     public function toArray($request)
     {
+        // this gets around augmented model wrapValue() returning handles 
+        // like meta->title instead of a nested array
+        // if that ever changes this could be removed
+        $augmentedArray = collect($this->resource->toAugmentedArray($this->blueprintFields))
+            ->mapWithKeys(fn ($item, $key) => [str_replace('->', '.', $key) => $item])
+            ->undot()
+            ->all();
+        
         return array_merge([
             $this->resource->getKeyName() => $this->resource->getKey(),
-        ], $this->resource
-            ->toAugmentedArray($this->blueprintFields)
+        ], $augmentedArray
         );
     }
 

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Http\Resources;
 
-use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 class ApiResource extends JsonResource
@@ -17,9 +16,7 @@ class ApiResource extends JsonResource
      */
     public function toArray($request)
     {
-        $resource = Runway::findResourceByModel($this->resource);
-
-        $with = $resource->blueprint()
+        $with = $this->resource->runwayResource()->blueprint()
             ->fields()->all()
             ->filter->isRelationship()->keys()->all();
 

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -19,9 +19,7 @@ class ApiResource extends JsonResource
         return array_merge([
             $this->resource->getKeyName() => $this->resource->getKey(),
         ], $this->resource
-            ->toAugmentedCollection($this->blueprintFields ?? [])
-            ->withShallowNesting()
-            ->toArray()
+            ->toAugmentedArray($this->blueprintFields)
         );
     }
 

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ApiResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param \Illuminate\Http\Request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->resource
+            ->toAugmentedCollection()
+            ->withShallowNesting()
+            ->toArray();
+    }
+}

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -24,10 +24,9 @@ class ApiResource extends JsonResource
             ->undot()
             ->all();
 
-        return array_merge([
+        return array_merge($augmentedArray, [
             $this->resource->getKeyName() => $this->resource->getKey(),
-        ], $augmentedArray
-        );
+        ]);
     }
 
     /**

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -15,7 +15,7 @@ class ApiResource extends JsonResource
     public function toArray($request)
     {
         $fields = $this->resource->blueprint()->fields()->all()->map->handle()->all();
-        
+
         return array_merge([
             $this->resource->primaryKey() => $this->resource->model()->getKey(),
         ], $this->resource

--- a/src/Http/Resources/ApiResource.php
+++ b/src/Http/Resources/ApiResource.php
@@ -15,11 +15,11 @@ class ApiResource extends JsonResource
     public function toArray($request)
     {
         return array_merge([
-                $this->resource->primaryKey() => $this->resource->model()->getKey(),   
-            ], $this->resource
-                ->toAugmentedCollection()
-                ->withShallowNesting()
-                ->toArray()
-            );
+            $this->resource->primaryKey() => $this->resource->model()->getKey(),
+        ], $this->resource
+            ->toAugmentedCollection()
+            ->withShallowNesting()
+            ->toArray()
+        );
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,7 +9,6 @@ use DoubleThreeDigital\Runway\Search\Searchable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Statamic\API\Middleware\Cache;
 use Statamic\Facades\CP\Nav;
@@ -171,12 +170,8 @@ class ServiceProvider extends AddonServiceProvider
                     ->name('statamic.api.')
                     ->prefix(config('statamic.api.route'))
                     ->group(function () {
-                        Runway::allResources()
-                            ->each(function (Resource $resource) {
-                                $handle = Str::plural($resource->handle());
-                                Route::name('runway.'.$handle.'.index')->get('runway/{resource}', [RestApiController::class, 'index']);
-                                Route::name('runway.'.$handle.'.show')->get('runway/{resource}/{id}', [RestApiController::class, 'show']);
-                            });
+                        Route::name('runway.restapi.index')->get('runway/{resource}', [RestApiController::class, 'index']);
+                        Route::name('runway.restapi.show')->get('runway/{resource}/{id}', [RestApiController::class, 'show']);
                     });
             });
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace DoubleThreeDigital\Runway;
 
-use DoubleThreeDigital\Runway\Http\Controllers\RestApiController;
+use DoubleThreeDigital\Runway\Http\Controllers\ApiController;
 use DoubleThreeDigital\Runway\Policies\ResourcePolicy;
 use DoubleThreeDigital\Runway\Search\Provider as SearchProvider;
 use DoubleThreeDigital\Runway\Search\Searchable;
@@ -178,8 +178,8 @@ class ServiceProvider extends AddonServiceProvider
                     ->name('statamic.api.')
                     ->prefix(config('statamic.api.route'))
                     ->group(function () {
-                        Route::name('runway.index')->get('runway/{handle}', [RestApiController::class, 'index']);
-                        Route::name('runway.show')->get('runway/{handle}/{id}', [RestApiController::class, 'show']);
+                        Route::name('runway.index')->get('runway/{handle}', [ApiController::class, 'index']);
+                        Route::name('runway.show')->get('runway/{handle}/{id}', [ApiController::class, 'show']);
                     });
             });
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -157,7 +157,7 @@ class ServiceProvider extends AddonServiceProvider
                 GraphQL::addQuery("runway_graphql_queries_{$resource->handle()}_show");
             });
     }
-    
+
     protected function bootRestApi()
     {
         if (config('statamic.api.enabled')) {
@@ -169,7 +169,7 @@ class ServiceProvider extends AddonServiceProvider
                 Route::middleware(config('statamic.api.middleware'))
                     ->name('statamic.api.')
                     ->prefix(config('statamic.api.route'))
-                    ->group(function () { 
+                    ->group(function () {
                         Runway::allResources()
                             ->each(function (Resource $resource) {
                                 Route::name('runway.'.$resource->handle().'.index')->get('runway/{resource}', [RestApiController::class, 'index']);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,6 +9,7 @@ use DoubleThreeDigital\Runway\Search\Searchable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Conditionable;
 use Statamic\API\Middleware\Cache;
 use Statamic\Facades\CP\Nav;
@@ -172,8 +173,9 @@ class ServiceProvider extends AddonServiceProvider
                     ->group(function () {
                         Runway::allResources()
                             ->each(function (Resource $resource) {
-                                Route::name('runway.'.$resource->handle().'.index')->get('runway/{resource}', [RestApiController::class, 'index']);
-                                Route::name('runway.'.$resource->handle().'.show')->get('runway/{resource}/{id}', [RestApiController::class, 'show']);
+                                $handle = Str::plural($resource->handle());
+                                Route::name('runway.'.$handle.'.index')->get('runway/{resource}', [RestApiController::class, 'index']);
+                                Route::name('runway.'.$handle.'.show')->get('runway/{resource}/{id}', [RestApiController::class, 'show']);
                             });
                     });
             });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -86,7 +86,7 @@ class ServiceProvider extends AddonServiceProvider
             $this->registerPolicies();
             $this->registerNavigation();
             $this->bootGraphQl();
-            $this->bootRestApi();
+            $this->bootApi();
 
             SearchProvider::register();
             $this->bootModelEventListeners();
@@ -166,7 +166,7 @@ class ServiceProvider extends AddonServiceProvider
             });
     }
 
-    protected function bootRestApi()
+    protected function bootApi()
     {
         if (config('statamic.api.enabled')) {
             Route::middleware([

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -178,8 +178,8 @@ class ServiceProvider extends AddonServiceProvider
                     ->name('statamic.api.')
                     ->prefix(config('statamic.api.route'))
                     ->group(function () {
-                        Route::name('runway.index')->get('runway/{resource}', [RestApiController::class, 'index']);
-                        Route::name('runway.show')->get('runway/{resource}/{id}', [RestApiController::class, 'show']);
+                        Route::name('runway.index')->get('runway/{handle}', [RestApiController::class, 'index']);
+                        Route::name('runway.show')->get('runway/{handle}/{id}', [RestApiController::class, 'show']);
                     });
             });
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -178,8 +178,8 @@ class ServiceProvider extends AddonServiceProvider
                     ->name('statamic.api.')
                     ->prefix(config('statamic.api.route'))
                     ->group(function () {
-                        Route::name('runway.index')->get('runway/{handle}', [ApiController::class, 'index']);
-                        Route::name('runway.show')->get('runway/{handle}/{id}', [ApiController::class, 'show']);
+                        Route::name('runway.index')->get('runway/{resourceHandle}', [ApiController::class, 'index']);
+                        Route::name('runway.show')->get('runway/{resourceHandle}/{record}', [ApiController::class, 'show']);
                     });
             });
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -170,8 +170,8 @@ class ServiceProvider extends AddonServiceProvider
                     ->name('statamic.api.')
                     ->prefix(config('statamic.api.route'))
                     ->group(function () {
-                        Route::name('runway.restapi.index')->get('runway/{resource}', [RestApiController::class, 'index']);
-                        Route::name('runway.restapi.show')->get('runway/{resource}/{id}', [RestApiController::class, 'show']);
+                        Route::name('runway.index')->get('runway/{resource}', [RestApiController::class, 'index']);
+                        Route::name('runway.show')->get('runway/{resource}/{id}', [RestApiController::class, 'show']);
                     });
             });
         }

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -27,6 +27,11 @@ trait HasRunwayResource
         return new AugmentedModel($this);
     }
 
+    public function shallowAugmentedArrayKeys()
+    {
+        return [$this->runwayResource()->primaryKey(), $this->runwayResource()->titleField(), 'api_url'];
+    }
+
     public function runwayResource(): Resource
     {
         return Runway::findResourceByModel($this);

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -54,6 +54,26 @@ class ApiControllerTest extends TestCase
     }
 
     /** @test */
+    public function gets_a_resource_model_with_nested_fields()
+    {
+        $post = Post::factory()->create([
+            'values' => [
+                'alt_title' => 'Alternative Title...',
+                'alt_body' => 'This is a **great** post! You should *read* it.',
+            ],
+        ]);
+
+        $this
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'record' => $post->id]))
+            ->assertOk()
+            ->assertSee(['data'])
+            ->assertJsonPath('data.id', $post->id)
+            ->assertJsonPath('data.values.alt_title', 'Alternative Title...')
+            ->assertJsonPath('data.values.alt_body', '<p>This is a <strong>great</strong> post! You should <em>read</em> it.</p>
+');
+    }
+
+    /** @test */
     public function returns_not_found_on_a_model_that_does_not_exist()
     {
         $this

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
+
+use DoubleThreeDigital\Runway\Runway;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
+use DoubleThreeDigital\Runway\Tests\TestCase;
+use Statamic\Facades\Config;
+use Statamic\Facades\User;
+
+class ApiControllerTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('statamic.api.resources.runway', [
+            'posts' => ['allowed_filters' => ['title']],
+        ]);
+    }
+    
+    /** @test */
+    public function gets_a_resource_that_exists()
+    {
+        Post::factory()->count(2)->create();
+
+        $response = $this
+            ->get(route('statamic.api.runway.index', ['handle' => 'posts']))
+            ->assertOk()
+            ->assertSee([
+                'data',
+                'meta',
+            ]);
+            
+        $ids = collect($response->json()['data'])->pluck('id')->values()->all();
+            
+        $this->assertSame($ids, Post::all()->pluck('id')->values()->all());
+    }
+    
+    /** @test */
+    public function returns_not_found_on_a_resource_that_doesnt_exist()
+    {
+        Post::factory()->count(2)->create();
+
+        $response = $this
+            ->get(route('statamic.api.runway.index', ['handle' => 'posts2']))
+            ->assertNotFound();
+    }
+    
+    /** @test */
+    public function gets_a_resource_model_that_exists()
+    {
+        Post::factory()->count(2)->create();
+
+        $response = $this
+            ->get(route('statamic.api.runway.show', ['handle' => 'posts', 'id' => 1]))
+            ->assertOk()
+            ->assertSee([
+                'data',
+            ]);
+    }
+
+    /** @test */
+    public function returns_not_found_on_a_model_that_doesnt_exist()
+    {
+        Post::factory()->count(2)->create();
+        $user = User::make()->makeSuper()->save();
+
+        $response = $this
+            ->get(route('statamic.api.runway.show', ['handle' => 'posts', 'id' => 44]))
+            ->assertNotFound();
+    }
+    
+    /** @test */
+    public function paginates_a_resource_list()
+    {
+        Post::factory()->count(10)->create();
+
+        $response = $this
+            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'limit' => 5]))
+            ->assertOk()
+            ->assertSee([
+                'data',
+                'meta',
+            ]);
+                        
+        $json = $response->json();
+        
+        $this->assertSame($json['meta']['current_page'], 1);
+        $this->assertSame($json['meta']['last_page'], 2);
+        $this->assertSame($json['meta']['total'], 10);
+        
+        $response = $this
+            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'limit' => 5, 'page' => 2]))
+            ->assertOk()
+            ->assertSee([
+                'data',
+                'meta',
+            ]);
+                        
+        $json = $response->json();
+        
+        $this->assertSame($json['meta']['current_page'], 2);
+        $this->assertSame($json['meta']['last_page'], 2);
+        $this->assertSame($json['meta']['total'], 10);
+    }
+    
+    /** @test */
+    public function filters_a_resource_list()
+    {
+        Post::factory()->count(3)->create();        
+            
+        Post::find(1)->fill(['title' => 'Test One'])->save();
+        Post::find(2)->fill(['title' => 'Test Two'])->save();
+        Post::find(3)->fill(['title' => 'Test Three'])->save();
+
+        $response = $this
+            ->get(route('statamic.api.runway.index', ['handle' => 'posts']))
+            ->assertOk()
+            ->assertSee([
+                'data',
+                'meta',
+            ]);
+                        
+        $json = $response->json();
+        
+        $this->assertSame($json['meta']['total'], 3);
+        
+        $response = $this
+            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'filter[title:contains]' => 'one']))
+            ->assertOk()
+            ->assertSee([
+                'data',
+                'meta',
+            ]);
+                        
+        $json = $response->json();
+        
+        $this->assertSame($json['meta']['total'], 1);
+        
+        $response = $this
+            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'filter[title:contains]' => 'test']))
+            ->assertOk()
+            ->assertSee([
+                'data',
+                'meta',
+            ]);
+                        
+        $json = $response->json();
+        
+        $this->assertSame($json['meta']['total'], 3);
+    }
+    
+    /** @test */
+    public function wont_filter_a_resource_list_on_a_forbidden_filter()
+    {
+        Post::factory()->count(3)->create();        
+            
+        Post::find(1)->fill(['title' => 'Test One'])->save();
+        Post::find(2)->fill(['title' => 'Test Two'])->save();
+        Post::find(3)->fill(['title' => 'Test Three'])->save();
+
+        $this
+            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'filter[slug:contains]' => 'one']))
+            ->assertStatus(422);
+    }
+}

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -23,7 +23,7 @@ class ApiControllerTest extends TestCase
         $posts = Post::factory()->count(2)->create();
 
         $this
-            ->get(route('statamic.api.runway.index', ['handle' => 'posts']))
+            ->get(route('statamic.api.runway.index', ['resourceHandle' => 'posts']))
             ->assertOk()
             ->assertJsonStructure(['data', 'meta'])
             ->assertJsonPath('data.0.id', $posts[0]->id)
@@ -36,7 +36,7 @@ class ApiControllerTest extends TestCase
         Post::factory()->count(2)->create();
 
         $this
-            ->get(route('statamic.api.runway.index', ['handle' => 'posts2']))
+            ->get(route('statamic.api.runway.index', ['resourceHandle' => 'posts2']))
             ->assertNotFound();
     }
 
@@ -46,7 +46,7 @@ class ApiControllerTest extends TestCase
         $post = Post::factory()->create();
 
         $this
-            ->get(route('statamic.api.runway.show', ['handle' => 'posts', 'id' => $post->id]))
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'record' => $post->id]))
             ->assertOk()
             ->assertSee(['data'])
             ->assertJsonPath('data.id', $post->id)
@@ -57,7 +57,7 @@ class ApiControllerTest extends TestCase
     public function returns_not_found_on_a_model_that_does_not_exist()
     {
         $this
-            ->get(route('statamic.api.runway.show', ['handle' => 'posts', 'id' => 44]))
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'record' => 44]))
             ->assertNotFound();
     }
 
@@ -67,7 +67,7 @@ class ApiControllerTest extends TestCase
         Post::factory()->count(10)->create();
 
         $this
-            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'limit' => 5]))
+            ->get(route('statamic.api.runway.index', ['resourceHandle' => 'posts', 'limit' => 5]))
             ->assertOk()
             ->assertJsonStructure(['data', 'meta'])
             ->assertJsonPath('meta.current_page', 1)
@@ -75,7 +75,7 @@ class ApiControllerTest extends TestCase
             ->assertJsonPath('meta.total', 10);
 
         $this
-            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'limit' => 5, 'page' => 2]))
+            ->get(route('statamic.api.runway.index', ['resourceHandle' => 'posts', 'limit' => 5, 'page' => 2]))
             ->assertOk()
             ->assertJsonStructure(['data', 'meta'])
             ->assertJsonPath('meta.current_page', 2)
@@ -93,19 +93,19 @@ class ApiControllerTest extends TestCase
         $postC->update(['title' => 'Test Three']);
 
         $this
-            ->get(route('statamic.api.runway.index', ['handle' => 'posts']))
+            ->get(route('statamic.api.runway.index', ['resourceHandle' => 'posts']))
             ->assertOk()
             ->assertJsonStructure(['data', 'meta'])
             ->assertJsonPath('meta.total', 3);
 
         $this
-            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'filter[title:contains]' => 'one']))
+            ->get(route('statamic.api.runway.index', ['resourceHandle' => 'posts', 'filter[title:contains]' => 'one']))
             ->assertOk()
             ->assertJsonStructure(['data', 'meta'])
             ->assertJsonPath('meta.total', 1);
 
         $this
-            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'filter[title:contains]' => 'test']))
+            ->get(route('statamic.api.runway.index', ['resourceHandle' => 'posts', 'filter[title:contains]' => 'test']))
             ->assertOk()
             ->assertJsonStructure(['data', 'meta'])
             ->assertJsonPath('meta.total', 3);
@@ -121,7 +121,7 @@ class ApiControllerTest extends TestCase
         $postC->update(['title' => 'Test Three']);
 
         $this
-            ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'filter[slug:contains]' => 'one']))
+            ->get(route('statamic.api.runway.index', ['resourceHandle' => 'posts', 'filter[slug:contains]' => 'one']))
             ->assertStatus(422);
     }
 }

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -2,8 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
 
-use DoubleThreeDigital\Runway\Runway;
-use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Statamic\Facades\Config;
@@ -19,7 +17,7 @@ class ApiControllerTest extends TestCase
             'posts' => ['allowed_filters' => ['title']],
         ]);
     }
-    
+
     /** @test */
     public function gets_a_resource_that_exists()
     {
@@ -32,12 +30,12 @@ class ApiControllerTest extends TestCase
                 'data',
                 'meta',
             ]);
-            
+
         $ids = collect($response->json()['data'])->pluck('id')->values()->all();
-            
+
         $this->assertSame($ids, Post::all()->pluck('id')->values()->all());
     }
-    
+
     /** @test */
     public function returns_not_found_on_a_resource_that_doesnt_exist()
     {
@@ -47,7 +45,7 @@ class ApiControllerTest extends TestCase
             ->get(route('statamic.api.runway.index', ['handle' => 'posts2']))
             ->assertNotFound();
     }
-    
+
     /** @test */
     public function gets_a_resource_model_that_exists()
     {
@@ -71,7 +69,7 @@ class ApiControllerTest extends TestCase
             ->get(route('statamic.api.runway.show', ['handle' => 'posts', 'id' => 44]))
             ->assertNotFound();
     }
-    
+
     /** @test */
     public function paginates_a_resource_list()
     {
@@ -84,13 +82,13 @@ class ApiControllerTest extends TestCase
                 'data',
                 'meta',
             ]);
-                        
+
         $json = $response->json();
-        
+
         $this->assertSame($json['meta']['current_page'], 1);
         $this->assertSame($json['meta']['last_page'], 2);
         $this->assertSame($json['meta']['total'], 10);
-        
+
         $response = $this
             ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'limit' => 5, 'page' => 2]))
             ->assertOk()
@@ -98,19 +96,19 @@ class ApiControllerTest extends TestCase
                 'data',
                 'meta',
             ]);
-                        
+
         $json = $response->json();
-        
+
         $this->assertSame($json['meta']['current_page'], 2);
         $this->assertSame($json['meta']['last_page'], 2);
         $this->assertSame($json['meta']['total'], 10);
     }
-    
+
     /** @test */
     public function filters_a_resource_list()
     {
-        Post::factory()->count(3)->create();        
-            
+        Post::factory()->count(3)->create();
+
         Post::find(1)->fill(['title' => 'Test One'])->save();
         Post::find(2)->fill(['title' => 'Test Two'])->save();
         Post::find(3)->fill(['title' => 'Test Three'])->save();
@@ -122,11 +120,11 @@ class ApiControllerTest extends TestCase
                 'data',
                 'meta',
             ]);
-                        
+
         $json = $response->json();
-        
+
         $this->assertSame($json['meta']['total'], 3);
-        
+
         $response = $this
             ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'filter[title:contains]' => 'one']))
             ->assertOk()
@@ -134,11 +132,11 @@ class ApiControllerTest extends TestCase
                 'data',
                 'meta',
             ]);
-                        
+
         $json = $response->json();
-        
+
         $this->assertSame($json['meta']['total'], 1);
-        
+
         $response = $this
             ->get(route('statamic.api.runway.index', ['handle' => 'posts', 'filter[title:contains]' => 'test']))
             ->assertOk()
@@ -146,17 +144,17 @@ class ApiControllerTest extends TestCase
                 'data',
                 'meta',
             ]);
-                        
+
         $json = $response->json();
-        
+
         $this->assertSame($json['meta']['total'], 3);
     }
-    
+
     /** @test */
     public function wont_filter_a_resource_list_on_a_forbidden_filter()
     {
-        Post::factory()->count(3)->create();        
-            
+        Post::factory()->count(3)->create();
+
         Post::find(1)->fill(['title' => 'Test One'])->save();
         Post::find(2)->fill(['title' => 'Test Two'])->save();
         Post::find(3)->fill(['title' => 'Test Three'])->save();

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -74,6 +74,20 @@ class ApiControllerTest extends TestCase
     }
 
     /** @test */
+    public function gets_a_resource_model_with_belongs_to_relationship()
+    {
+        $post = Post::factory()->create();
+
+        $this
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'record' => $post->id]))
+            ->assertOk()
+            ->assertSee(['data'])
+            ->assertJsonPath('data.id', $post->id)
+            ->assertJsonPath('data.author_id.id', $post->author->id)
+            ->assertJsonPath('data.author_id.name', $post->author->name);
+    }
+
+    /** @test */
     public function returns_not_found_on_a_model_that_does_not_exist()
     {
         $this

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -100,7 +100,7 @@ abstract class TestCase extends OrchestraTestCase
         ]);
 
         $app['config']->set('runway', require(__DIR__.'/__fixtures__/config/runway.php'));
-        
+
         $app['config']->set('statamic.api.enabled', true);
         $app['config']->set('statamic.editions.pro', true);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -100,5 +100,8 @@ abstract class TestCase extends OrchestraTestCase
         ]);
 
         $app['config']->set('runway', require(__DIR__.'/__fixtures__/config/runway.php'));
+        
+        $app['config']->set('statamic.api.enabled', true);
+        $app['config']->set('statamic.editions.pro', true);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -92,6 +92,8 @@ abstract class TestCase extends OrchestraTestCase
             );
         }
 
+        $app['config']->set('statamic.api.enabled', true);
+        $app['config']->set('statamic.editions.pro', true);
         $app['config']->set('statamic.users.repository', 'file');
 
         $app['config']->set('statamic.stache.stores.users', [
@@ -100,8 +102,5 @@ abstract class TestCase extends OrchestraTestCase
         ]);
 
         $app['config']->set('runway', require(__DIR__.'/__fixtures__/config/runway.php'));
-
-        $app['config']->set('statamic.api.enabled', true);
-        $app['config']->set('statamic.editions.pro', true);
     }
 }


### PR DESCRIPTION
This PR brings REST Api support to Runway.

Ensure the API is enabled, then opt into any resources you want in `statamic.api.resources` under a `runway` key:

```php
'resources' => [
    'collections' => true,
    'navs' => false,
    'taxonomies' => false,
    'assets' => false,
    'globals' => true,
    'forms' => false,
    'users' => false,
    'runway' => [
        'users' => ['allowed_filters' => ['name']],
    ],
],
```

Then your resource list should be available at `/api/runway/{resource}`

To do:

- [x] Tests 
- [x] Ensure model key is in the returned fields
- [x] Write documentation