### PR TITLE
[6.x] Tidy up tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "autoload-dev": {
         "psr-4": {
             "DoubleThreeDigital\\Runway\\Tests\\": "tests",
-            "DoubleThreeDigital\\Runway\\Tests\\Fixtures\\": "tests/__fixtures__/app"
+            "DoubleThreeDigital\\Runway\\Tests\\Fixtures\\": "tests/__fixtures__/app",
+            "DoubleThreeDigital\\Runway\\Tests\\Fixtures\\Database\\Factories\\": "tests/__fixtures__/database/factories"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "DoubleThreeDigital\\Runway\\Tests\\": "tests"
+            "DoubleThreeDigital\\Runway\\Tests\\": "tests",
+            "DoubleThreeDigital\\Runway\\Tests\\Fixtures\\": "tests/__fixtures__/app"
         }
     },
     "extra": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,7 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
+    beStrictAboutTestsThatDoNotTestAnything="false"
 >
     <testsuites>
         <testsuite name="Test Suite">

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Tests\AugmentedModelTest;
+namespace DoubleThreeDigital\Runway\Tests\Data;
 
 use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -28,15 +28,15 @@ class AugmentedModelTest extends TestCase
 
         $augmented = new AugmentedModel($post);
 
-        $this->assertSame('My First Post', $augmented->get('title')->value());
-        $this->assertSame('my-first-post', $augmented->get('slug')->value());
-        $this->assertSame('Blah blah blah...', $augmented->get('body')->value());
-        $this->assertSame('2020-01-01 13:46:12', $augmented->get('created_at')->value()->format('Y-m-d H:i:s'));
-        $this->assertSame('/posts/my-first-post', $augmented->get('url')->value());
+        $this->assertEquals('My First Post', $augmented->get('title')->value());
+        $this->assertEquals('my-first-post', $augmented->get('slug')->value());
+        $this->assertEquals('Blah blah blah...', $augmented->get('body')->value());
+        $this->assertEquals('2020-01-01 13:46:12', $augmented->get('created_at')->value()->format('Y-m-d H:i:s'));
+        $this->assertEquals('/posts/my-first-post', $augmented->get('url')->value());
 
         $this->assertIsArray($augmented->get('author_id')->value());
-        $this->assertSame($author->id, $augmented->get('author_id')->value()['id']->value());
-        $this->assertSame('John Doe', $augmented->get('author_id')->value()['name']->value());
+        $this->assertEquals($author->id, $augmented->get('author_id')->value()['id']->value());
+        $this->assertEquals('John Doe', $augmented->get('author_id')->value()['name']->value());
     }
 
     /** @test */
@@ -53,7 +53,7 @@ class AugmentedModelTest extends TestCase
 
         $this->assertIsArray($augmented->get('values')->value());
 
-        $this->assertSame('Alternative Title...', $augmented->get('values')->value()['alt_title']->value());
-        $this->assertSame('<p>This is a <strong>great</strong> post! You should <em>read</em> it.</p>', trim($augmented->get('values')->value()['alt_body']->value()));
+        $this->assertEquals('Alternative Title...', $augmented->get('values')->value()['alt_title']->value());
+        $this->assertEquals('<p>This is a <strong>great</strong> post! You should <em>read</em> it.</p>', trim($augmented->get('values')->value()['alt_body']->value()));
     }
 }

--- a/tests/Data/AugmentedModelTest.php
+++ b/tests/Data/AugmentedModelTest.php
@@ -3,6 +3,8 @@
 namespace DoubleThreeDigital\Runway\Tests\AugmentedModelTest;
 
 use DoubleThreeDigital\Runway\Data\AugmentedModel;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Spatie\TestTime\TestTime;
 
@@ -13,11 +15,9 @@ class AugmentedModelTest extends TestCase
     {
         TestTime::freeze('Y-m-d H:i:s', '2020-01-01 13:46:12');
 
-        $author = $this->authorFactory(1, [
-            'name' => 'John Doe',
-        ]);
+        $author = Author::factory()->create(['name' => 'John Doe']);
 
-        $post = $this->postFactory(1, [
+        $post = Post::factory()->create([
             'title' => 'My First Post',
             'slug' => 'my-first-post',
             'body' => 'Blah blah blah...',
@@ -42,7 +42,7 @@ class AugmentedModelTest extends TestCase
     /** @test */
     public function it_gets_nested_values()
     {
-        $post = $this->postFactory(1, [
+        $post = Post::factory()->create([
             'values' => [
                 'alt_title' => 'Alternative Title...',
                 'alt_body' => 'This is a **great** post! You should *read* it.',

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -80,8 +80,8 @@ class BelongsToFieldtypeTest extends TestCase
     /** @test */
     public function can_get_index_items_in_order_specified_in_runway_config()
     {
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.order_by', 'name');
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.order_by_direction', 'desc');
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.order_by', 'name');
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.order_by_direction', 'desc');
 
         $authorOne = $this->authorFactory(1, [
             'name' => 'Scully',

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -46,11 +46,11 @@ class BelongsToFieldtypeTest extends TestCase
 
         $this->assertIsObject($getIndexItemsWithPagination);
         $this->assertTrue($getIndexItemsWithPagination instanceof Paginator);
-        $this->assertSame($getIndexItemsWithPagination->count(), 10);
+        $this->assertEquals($getIndexItemsWithPagination->count(), 10);
 
         $this->assertIsObject($getIndexItemsWithoutPagination);
         $this->assertTrue($getIndexItemsWithoutPagination instanceof Collection);
-        $this->assertSame($getIndexItemsWithoutPagination->count(), 10);
+        $this->assertEquals($getIndexItemsWithoutPagination->count(), 10);
     }
 
     /** @test */
@@ -71,10 +71,10 @@ class BelongsToFieldtypeTest extends TestCase
 
         $this->assertIsObject($getIndexItems);
         $this->assertTrue($getIndexItems instanceof Paginator);
-        $this->assertSame($getIndexItems->count(), 2);
+        $this->assertEquals($getIndexItems->count(), 2);
 
-        $this->assertSame($getIndexItems->first()['title'], 'AUTHOR '.$authors[0]->name);
-        $this->assertSame($getIndexItems->last()['title'], 'AUTHOR '.$authors[1]->name);
+        $this->assertEquals($getIndexItems->first()['title'], 'AUTHOR '.$authors[0]->name);
+        $this->assertEquals($getIndexItems->last()['title'], 'AUTHOR '.$authors[1]->name);
     }
 
     /** @test */
@@ -99,11 +99,11 @@ class BelongsToFieldtypeTest extends TestCase
 
         $this->assertIsObject($getIndexItems);
         $this->assertTrue($getIndexItems instanceof Collection);
-        $this->assertSame($getIndexItems->count(), 3);
+        $this->assertEquals($getIndexItems->count(), 3);
 
-        $this->assertSame($getIndexItems->all()[0]['title'], 'Scully');
-        $this->assertSame($getIndexItems->all()[1]['title'], 'Jake Peralta');
-        $this->assertSame($getIndexItems->all()[2]['title'], 'Amy Santiago');
+        $this->assertEquals($getIndexItems->all()[0]['title'], 'Scully');
+        $this->assertEquals($getIndexItems->all()[1]['title'], 'Jake Peralta');
+        $this->assertEquals($getIndexItems->all()[2]['title'], 'Amy Santiago');
     }
 
     /** @test */
@@ -122,7 +122,7 @@ class BelongsToFieldtypeTest extends TestCase
 
         $item = $this->fieldtype->getItemData([1]);
 
-        $this->assertSame('AUTHOR '.$author->name, $item->first()['title']);
+        $this->assertEquals('AUTHOR '.$author->name, $item->first()['title']);
     }
 
     /** @test */
@@ -134,7 +134,7 @@ class BelongsToFieldtypeTest extends TestCase
 
         $this->assertTrue($preProcessIndex instanceof Collection);
 
-        $this->assertSame($preProcessIndex->first(), [
+        $this->assertEquals($preProcessIndex->first(), [
             'id' => $author->id,
             'title' => $author->name,
             'edit_url' => 'http://localhost/cp/runway/author/1',
@@ -149,8 +149,8 @@ class BelongsToFieldtypeTest extends TestCase
         $augment = $this->fieldtype->augment($author->id);
 
         $this->assertIsArray($augment);
-        $this->assertSame($author->id, $augment['id']->value());
-        $this->assertSame($author->name, $augment['name']->value());
+        $this->assertEquals($author->id, $augment['id']->value());
+        $this->assertEquals($author->name, $augment['name']->value());
     }
 
     /**

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\Runway\Tests\Fieldtypes;
 
 use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -34,7 +35,7 @@ class BelongsToFieldtypeTest extends TestCase
     /** @test */
     public function can_get_index_items()
     {
-        $authors = $this->authorFactory(10);
+        Author::factory()->count(10)->create();
 
         $getIndexItemsWithPagination = $this->fieldtype->getIndexItems(
             new FilteredRequest(['paginate' => true])
@@ -56,7 +57,7 @@ class BelongsToFieldtypeTest extends TestCase
     /** @test */
     public function can_get_index_items_with_title_format()
     {
-        $authors = $this->authorFactory(2);
+        $authors = Author::factory()->count(2)->create();
 
         $this->fieldtype->setField(new Field('author', [
             'max_items' => 1,
@@ -83,17 +84,9 @@ class BelongsToFieldtypeTest extends TestCase
         Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.order_by', 'name');
         Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.order_by_direction', 'desc');
 
-        $authorOne = $this->authorFactory(1, [
-            'name' => 'Scully',
-        ]);
-
-        $authorTwo = $this->authorFactory(1, [
-            'name' => 'Jake Peralta',
-        ]);
-
-        $authorThree = $this->authorFactory(1, [
-            'name' => 'Amy Santiago',
-        ]);
+        $authorOne = Author::factory()->create(['name' => 'Scully']);
+        $authorTwo = Author::factory()->create(['name' => 'Jake Peralta']);
+        $authorThree = Author::factory()->create(['name' => 'Amy Santiago']);
 
         $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false]));
 
@@ -109,7 +102,7 @@ class BelongsToFieldtypeTest extends TestCase
     /** @test */
     public function can_get_item_array_with_title_format()
     {
-        $author = $this->authorFactory();
+        $author = Author::factory()->create();
 
         $this->fieldtype->setField(new Field('author', [
             'max_items' => 1,
@@ -128,7 +121,7 @@ class BelongsToFieldtypeTest extends TestCase
     /** @test */
     public function can_get_pre_process_index()
     {
-        $author = $this->authorFactory();
+        $author = Author::factory()->create();
 
         $preProcessIndex = $this->fieldtype->preProcessIndex($author->id);
 
@@ -144,7 +137,7 @@ class BelongsToFieldtypeTest extends TestCase
     /** @test */
     public function can_get_augment_value()
     {
-        $author = $this->authorFactory();
+        $author = Author::factory()->create();
 
         $augment = $this->fieldtype->augment($author->id);
 
@@ -160,7 +153,7 @@ class BelongsToFieldtypeTest extends TestCase
      */
     public function can_get_item_data()
     {
-        $author = $this->authorFactory();
+        $author = Author::factory()->create();
 
         $getItemData = $this->fieldtype->getItemData($author->id);
 

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -84,9 +84,9 @@ class BelongsToFieldtypeTest extends TestCase
         Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.order_by', 'name');
         Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.order_by_direction', 'desc');
 
-        $authorOne = Author::factory()->create(['name' => 'Scully']);
-        $authorTwo = Author::factory()->create(['name' => 'Jake Peralta']);
-        $authorThree = Author::factory()->create(['name' => 'Amy Santiago']);
+        Author::factory()->create(['name' => 'Scully']);
+        Author::factory()->create(['name' => 'Jake Peralta']);
+        Author::factory()->create(['name' => 'Amy Santiago']);
 
         $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false]));
 

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -71,12 +71,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_index_items()
     {
-        $posts = Post::factory()->count(10)->create();
         $author = Author::factory()->create();
-
-        foreach ($posts as $post) {
-            $post->update(['author_id' => $author->id]);
-        }
+        Post::factory()->count(10)->create(['author_id' => $author->id]);
 
         $getIndexItemsWithPagination = $this->fieldtype->getIndexItems(
             new FilteredRequest(['paginate' => true])
@@ -98,12 +94,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_index_items_with_title_format()
     {
-        $posts = Post::factory()->count(2)->create();
         $author = Author::factory()->create();
-
-        foreach ($posts as $post) {
-            $post->update(['author_id' => $author->id]);
-        }
+        $posts = Post::factory()->count(2)->create(['author_id' => $author->id]);
 
         $this->fieldtype->setField(new Field('posts', [
             'mode' => 'default',
@@ -126,12 +118,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_item_array_with_title_format()
     {
-        $posts = Post::factory()->count(2)->create();
         $author = Author::factory()->create();
-
-        foreach ($posts as $post) {
-            $post->update(['author_id' => $author->id]);
-        }
+        $posts = Post::factory()->count(2)->create(['author_id' => $author->id]);
 
         $this->fieldtype->setField(new Field('posts', [
             'mode' => 'default',
@@ -150,12 +138,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_pre_process_index()
     {
-        $posts = Post::factory()->count(10)->create();
         $author = Author::factory()->create();
-
-        foreach ($posts as $post) {
-            $post->update(['author_id' => $author->id]);
-        }
+        $posts = Post::factory()->count(10)->create(['author_id' => $author->id]);
 
         $preProcessIndex = $this->fieldtype->preProcessIndex($author->posts);
 
@@ -171,8 +155,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_process_and_add_relations_to_model()
     {
-        $posts = Post::factory()->count(10)->create();
         $author = Author::factory()->create();
+        $posts = Post::factory()->count(10)->create();
 
         // Usually these bits would be fetched from the request. However, as we can't mock
         // the request, we're using Blink.
@@ -197,8 +181,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_process_and_add_relations_to_model_with_pivot_table()
     {
-        $posts = Post::factory()->count(3)->create();
         $author = Author::factory()->create();
+        $posts = Post::factory()->count(3)->create();
 
         // Usually these bits would be fetched from the request. However, as we can't mock
         // the request, we're using Blink.
@@ -231,8 +215,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_process_and_add_relations_to_model_and_can_persist_users_sort_order()
     {
-        $posts = Post::factory()->count(3)->create();
         $author = Author::factory()->create();
+        $posts = Post::factory()->count(3)->create();
 
         $this->fieldtype->field()->setConfig(array_merge($this->fieldtype->field()->config(), [
             'reorderable' => true,
@@ -278,8 +262,8 @@ class HasManyFieldtypeTest extends TestCase
      */
     public function can_process_and_add_relations_to_model_and_can_persist_users_sort_order_on_pivot_table()
     {
-        $posts = Post::factory()->count(3)->create();
         $author = Author::factory()->create();
+        $posts = Post::factory()->count(3)->create();
 
         $this->fieldtypeUsingPivotTable->field()->setConfig(array_merge($this->fieldtypeUsingPivotTable->field()->config(), [
             'reorderable' => true,
@@ -320,12 +304,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_augment_value()
     {
-        $posts = Post::factory()->count(5)->create();
         $author = Author::factory()->create();
-
-        foreach ($posts as $post) {
-            $post->update(['author_id' => $author->id]);
-        }
+        $posts = Post::factory()->count(5)->create(['author_id' => $author->id]);
 
         $augment = $this->fieldtype->augment(
             $author->posts->pluck('id')->toArray()
@@ -345,12 +325,8 @@ class HasManyFieldtypeTest extends TestCase
      */
     public function can_get_item_data()
     {
-        $posts = Post::factory()->count(5)->create();
         $author = Author::factory()->create();
-
-        foreach ($posts as $post) {
-            $post->update(['author_id' => $author->id]);
-        }
+        $posts = Post::factory()->count(5)->create(['author_id' => $author->id]);
 
         $getItemData = $this->fieldtype->getItemData(
             $author->posts

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -3,6 +3,8 @@
 namespace DoubleThreeDigital\Runway\Tests\Fieldtypes;
 
 use DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -69,8 +71,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_index_items()
     {
-        $posts = $this->postFactory(10);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(10)->create();
+        $author = Author::factory()->create();
 
         foreach ($posts as $post) {
             $post->update(['author_id' => $author->id]);
@@ -96,8 +98,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_index_items_with_title_format()
     {
-        $posts = $this->postFactory(2);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(2)->create();
+        $author = Author::factory()->create();
 
         foreach ($posts as $post) {
             $post->update(['author_id' => $author->id]);
@@ -124,8 +126,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_item_array_with_title_format()
     {
-        $posts = $this->postFactory(2);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(2)->create();
+        $author = Author::factory()->create();
 
         foreach ($posts as $post) {
             $post->update(['author_id' => $author->id]);
@@ -148,8 +150,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_pre_process_index()
     {
-        $posts = $this->postFactory(10);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(10)->create();
+        $author = Author::factory()->create();
 
         foreach ($posts as $post) {
             $post->update(['author_id' => $author->id]);
@@ -169,8 +171,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_process_and_add_relations_to_model()
     {
-        $posts = $this->postFactory(10);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(10)->create();
+        $author = Author::factory()->create();
 
         // Usually these bits would be fetched from the request. However, as we can't mock
         // the request, we're using Blink.
@@ -195,8 +197,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_process_and_add_relations_to_model_with_pivot_table()
     {
-        $posts = $this->postFactory(3);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(3)->create();
+        $author = Author::factory()->create();
 
         // Usually these bits would be fetched from the request. However, as we can't mock
         // the request, we're using Blink.
@@ -229,8 +231,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_process_and_add_relations_to_model_and_can_persist_users_sort_order()
     {
-        $posts = $this->postFactory(3);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(3)->create();
+        $author = Author::factory()->create();
 
         $this->fieldtype->field()->setConfig(array_merge($this->fieldtype->field()->config(), [
             'reorderable' => true,
@@ -276,8 +278,8 @@ class HasManyFieldtypeTest extends TestCase
      */
     public function can_process_and_add_relations_to_model_and_can_persist_users_sort_order_on_pivot_table()
     {
-        $posts = $this->postFactory(3);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(3)->create();
+        $author = Author::factory()->create();
 
         $this->fieldtypeUsingPivotTable->field()->setConfig(array_merge($this->fieldtypeUsingPivotTable->field()->config(), [
             'reorderable' => true,
@@ -318,8 +320,8 @@ class HasManyFieldtypeTest extends TestCase
     /** @test */
     public function can_get_augment_value()
     {
-        $posts = $this->postFactory(5);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(5)->create();
+        $author = Author::factory()->create();
 
         foreach ($posts as $post) {
             $post->update(['author_id' => $author->id]);
@@ -343,8 +345,8 @@ class HasManyFieldtypeTest extends TestCase
      */
     public function can_get_item_data()
     {
-        $posts = $this->postFactory(5);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(5)->create();
+        $author = Author::factory()->create();
 
         foreach ($posts as $post) {
             $post->update(['author_id' => $author->id]);

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -24,7 +24,7 @@ class HasManyFieldtypeTest extends TestCase
     {
         parent::setUp();
 
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.blueprint.sections.main.fields', [
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.blueprint.sections.main.fields', [
             [
                 'handle' => 'name',
                 'field' => [

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -86,11 +86,11 @@ class HasManyFieldtypeTest extends TestCase
 
         $this->assertIsObject($getIndexItemsWithPagination);
         $this->assertTrue($getIndexItemsWithPagination instanceof Paginator);
-        $this->assertSame($getIndexItemsWithPagination->count(), 10);
+        $this->assertEquals($getIndexItemsWithPagination->count(), 10);
 
         $this->assertIsObject($getIndexItemsWithoutPagination);
         $this->assertTrue($getIndexItemsWithoutPagination instanceof Collection);
-        $this->assertSame($getIndexItemsWithoutPagination->count(), 10);
+        $this->assertEquals($getIndexItemsWithoutPagination->count(), 10);
     }
 
     /** @test */
@@ -115,10 +115,10 @@ class HasManyFieldtypeTest extends TestCase
 
         $this->assertIsObject($getIndexItems);
         $this->assertTrue($getIndexItems instanceof Paginator);
-        $this->assertSame($getIndexItems->count(), 2);
+        $this->assertEquals($getIndexItems->count(), 2);
 
-        $this->assertSame($getIndexItems->first()['title'], $posts[0]->title.' TEST '.now()->format('Y'));
-        $this->assertSame($getIndexItems->last()['title'], $posts[1]->title.' TEST '.now()->format('Y'));
+        $this->assertEquals($getIndexItems->first()['title'], $posts[0]->title.' TEST '.now()->format('Y'));
+        $this->assertEquals($getIndexItems->last()['title'], $posts[1]->title.' TEST '.now()->format('Y'));
     }
 
     /** @test */
@@ -141,8 +141,8 @@ class HasManyFieldtypeTest extends TestCase
 
         $item = $this->fieldtype->getItemData([$posts[0]->id, $posts[1]->id]);
 
-        $this->assertSame($item->first()['title'], $posts[0]->title.' TEST '.now()->format('Y'));
-        $this->assertSame($item->last()['title'], $posts[1]->title.' TEST '.now()->format('Y'));
+        $this->assertEquals($item->first()['title'], $posts[0]->title.' TEST '.now()->format('Y'));
+        $this->assertEquals($item->last()['title'], $posts[1]->title.' TEST '.now()->format('Y'));
     }
 
     /** @test */
@@ -159,7 +159,7 @@ class HasManyFieldtypeTest extends TestCase
 
         $this->assertTrue($preProcessIndex instanceof Collection);
 
-        $this->assertSame($preProcessIndex->first(), [
+        $this->assertEquals($preProcessIndex->first(), [
             'id' => $posts[0]->id,
             'title' => $posts[0]->title,
             'edit_url' => 'http://localhost/cp/runway/post/'.$posts[0]->id,
@@ -180,16 +180,16 @@ class HasManyFieldtypeTest extends TestCase
         $this->fieldtype->process(collect($posts)->pluck('id')->toArray());
 
         // Ensure the author is attached to all 10 posts
-        $this->assertSame($posts[0]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[1]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[2]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[3]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[4]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[5]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[6]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[7]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[8]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[9]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[0]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[1]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[2]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[3]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[4]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[5]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[6]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[7]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[8]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[9]->fresh()->author_id, $author->id);
     }
 
     /** @test */
@@ -249,9 +249,9 @@ class HasManyFieldtypeTest extends TestCase
         ]);
 
         // Ensure the author is attached to all 3 posts
-        $this->assertSame($posts[0]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[1]->fresh()->author_id, $author->id);
-        $this->assertSame($posts[2]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[0]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[1]->fresh()->author_id, $author->id);
+        $this->assertEquals($posts[2]->fresh()->author_id, $author->id);
 
         // Ensure the sort_order is persisted correctly for all 3 posts
         $this->assertDatabaseHas('posts', [
@@ -332,8 +332,8 @@ class HasManyFieldtypeTest extends TestCase
         $this->assertIsArray($augment);
         $this->assertCount(5, $augment);
 
-        $this->assertSame($posts[0]->id, $augment[0]['id']->value());
-        $this->assertSame($posts[0]->title, (string) $augment[0]['title']->value());
+        $this->assertEquals($posts[0]->id, $augment[0]['id']->value());
+        $this->assertEquals($posts[0]->title, (string) $augment[0]['title']->value());
     }
 
     /**

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -3,22 +3,23 @@
 namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
 
 use DoubleThreeDigital\Runway\Runway;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Statamic\Facades\Config;
 use Statamic\Facades\User;
 
 class ResourceControllerTest extends TestCase
 {
-    use RefreshDatabase;
+    use RefreshDatabase, WithFaker;
 
     /** @test */
     public function get_model_index()
     {
+        Post::factory()->count(2)->create();
         $user = User::make()->makeSuper()->save();
-
-        $posts = $this->postFactory(2);
 
         $this->actingAs($user)
             ->get(cp_route('runway.index', ['resourceHandle' => 'post']))
@@ -57,9 +58,8 @@ class ResourceControllerTest extends TestCase
     /** @test */
     public function can_store_resource()
     {
+        $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $author = $this->authorFactory();
 
         $this->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
@@ -85,9 +85,8 @@ class ResourceControllerTest extends TestCase
 
         Runway::discoverResources();
 
+        $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $author = $this->authorFactory();
 
         $this->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
@@ -109,9 +108,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_store_resource_and_ensure_computed_field_isnt_saved_to_database()
     {
+        $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $author = $this->authorFactory();
 
         $this->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
@@ -137,9 +135,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_store_resource_and_ensure_field_isnt_saved_to_database()
     {
+        $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $author = $this->authorFactory();
 
         $this->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
@@ -165,9 +162,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_store_resource_and_ensure_appended_attribute_doesnt_attempt_to_get_saved()
     {
+        $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $author = $this->authorFactory();
 
         $this->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
@@ -193,9 +189,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_store_resource_with_nested_field()
     {
+        $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $author = $this->authorFactory();
 
         $this->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
@@ -221,9 +216,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_store_resource_and_ensure_date_comparison_validation_works()
     {
+        $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $author = $this->authorFactory();
 
         $this->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
@@ -250,9 +244,8 @@ class ResourceControllerTest extends TestCase
     /** @test */
     public function can_edit_resource()
     {
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
@@ -292,7 +285,7 @@ class ResourceControllerTest extends TestCase
         Runway::discoverResources();
 
         $user = User::make()->makeSuper()->save();
-        $post = $this->postFactory();
+        $post = Post::factory()->create();
 
         $resource = Runway::findResource('post');
         $record = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
@@ -335,8 +328,8 @@ class ResourceControllerTest extends TestCase
 
         Runway::discoverResources();
 
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-        $post = $this->postFactory();
 
         $resource = Runway::findResource('post');
         $record = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
@@ -379,8 +372,8 @@ class ResourceControllerTest extends TestCase
 
         Runway::discoverResources();
 
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-        $post = $this->postFactory();
 
         $resource = Runway::findResource('post');
         $record = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
@@ -409,15 +402,13 @@ class ResourceControllerTest extends TestCase
      */
     public function can_edit_resource_with_nested_field()
     {
-        $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory(
-            attributes: [
-                'values' => [
-                    'alt_title' => $this->faker->words(6, asText: true),
-                ],
+        $post = Post::factory()->create([
+            'values' => [
+                'alt_title' => $this->faker->words(6, asText: true),
             ],
-        );
+        ]);
+
+        $user = User::make()->makeSuper()->save();
 
         $this->actingAs($user)
             ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
@@ -434,9 +425,8 @@ class ResourceControllerTest extends TestCase
 
         Runway::discoverResources();
 
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
@@ -448,9 +438,8 @@ class ResourceControllerTest extends TestCase
     /** @test */
     public function can_update_resource()
     {
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
@@ -475,9 +464,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_update_resource_when_being_updated_from_inline_publish_form()
     {
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
@@ -504,9 +492,8 @@ class ResourceControllerTest extends TestCase
 
         Runway::discoverResources();
 
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
@@ -525,9 +512,8 @@ class ResourceControllerTest extends TestCase
     /** @test */
     public function can_update_resource_and_ensure_computed_field_isnt_saved_to_database()
     {
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
@@ -553,9 +539,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_update_resource_and_ensure__field_isnt_saved_to_database()
     {
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
@@ -581,9 +566,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_update_resource_and_ensure_appended_attribute_doesnt_attempt_to_get_saved()
     {
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
@@ -609,9 +593,8 @@ class ResourceControllerTest extends TestCase
      */
     public function can_update_resource_with_nested_field()
     {
+        $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
-
-        $post = $this->postFactory();
 
         $this->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -3,7 +3,7 @@
 namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
 
 use DoubleThreeDigital\Runway\Runway;
-use DoubleThreeDigital\Runway\Tests\Post;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Statamic\Facades\Config;

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -415,7 +415,7 @@ class ResourceControllerTest extends TestCase
     {
         $post = Post::factory()->create([
             'values' => [
-                'alt_title' => "Im Toby Ziegler, and I work at the White House.",
+                'alt_title' => 'Im Toby Ziegler, and I work at the White House.',
             ],
         ]);
 
@@ -427,7 +427,7 @@ class ResourceControllerTest extends TestCase
             ->assertOk()
             ->assertSee($post->title)
             ->assertSee($post->body)
-            ->assertSee("Im Toby Ziegler, and I work at the White House.");
+            ->assertSee('Im Toby Ziegler, and I work at the White House.');
     }
 
     /** @test */

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -466,7 +466,7 @@ class ResourceControllerTest extends TestCase
 
         $post->refresh();
 
-        $this->assertSame($post->title, 'Santa is coming home');
+        $this->assertEquals($post->title, 'Santa is coming home');
     }
 
     /**
@@ -494,7 +494,7 @@ class ResourceControllerTest extends TestCase
 
         $post->refresh();
 
-        $this->assertSame($post->title, 'Santa is coming home');
+        $this->assertEquals($post->title, 'Santa is coming home');
     }
 
     /** @test */
@@ -544,7 +544,7 @@ class ResourceControllerTest extends TestCase
 
         $post->refresh();
 
-        $this->assertSame($post->title, 'Santa is coming home');
+        $this->assertEquals($post->title, 'Santa is coming home');
     }
 
     /**
@@ -572,7 +572,7 @@ class ResourceControllerTest extends TestCase
 
         $post->refresh();
 
-        $this->assertSame($post->title, 'Santa is coming home');
+        $this->assertEquals($post->title, 'Santa is coming home');
     }
 
     /**
@@ -600,7 +600,7 @@ class ResourceControllerTest extends TestCase
 
         $post->refresh();
 
-        $this->assertSame($post->title, 'Santa is coming home');
+        $this->assertEquals($post->title, 'Santa is coming home');
     }
 
     /**
@@ -628,6 +628,6 @@ class ResourceControllerTest extends TestCase
 
         $post->refresh();
 
-        $this->assertSame($post->values['alt_title'], 'Claus is venturing out');
+        $this->assertEquals($post->values['alt_title'], 'Claus is venturing out');
     }
 }

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -6,22 +6,19 @@ use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Statamic\Facades\Config;
 use Statamic\Facades\User;
 
 class ResourceControllerTest extends TestCase
 {
-    use RefreshDatabase, WithFaker;
-
     /** @test */
     public function get_model_index()
     {
         Post::factory()->count(2)->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.index', ['resourceHandle' => 'post']))
             ->assertOk()
             ->assertViewIs('runway::index')
@@ -36,7 +33,8 @@ class ResourceControllerTest extends TestCase
     {
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.create', ['resourceHandle' => 'post']))
             ->assertOk();
     }
@@ -50,7 +48,8 @@ class ResourceControllerTest extends TestCase
 
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.create', ['resourceHandle' => 'post']))
             ->assertRedirect();
     }
@@ -61,7 +60,8 @@ class ResourceControllerTest extends TestCase
         $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
@@ -88,7 +88,8 @@ class ResourceControllerTest extends TestCase
         $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
@@ -111,7 +112,8 @@ class ResourceControllerTest extends TestCase
         $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
@@ -138,7 +140,8 @@ class ResourceControllerTest extends TestCase
         $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
@@ -165,7 +168,8 @@ class ResourceControllerTest extends TestCase
         $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
@@ -192,7 +196,8 @@ class ResourceControllerTest extends TestCase
         $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
@@ -219,7 +224,8 @@ class ResourceControllerTest extends TestCase
         $author = Author::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
@@ -247,7 +253,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
@@ -259,7 +266,8 @@ class ResourceControllerTest extends TestCase
     {
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => 12345]))
             ->assertNotFound()
             ->assertSee('Page Not Found');
@@ -292,7 +300,8 @@ class ResourceControllerTest extends TestCase
 
         $this->assertEquals($post->getKey(), $record->getKey());
 
-        $response = $this->actingAs($user)
+        $response = $this
+            ->actingAs($user)
             ->get(cp_route('runway.edit', [
                 'resourceHandle' => 'post',
                 'record' => $post->id,
@@ -336,7 +345,8 @@ class ResourceControllerTest extends TestCase
 
         $this->assertEquals($post->getKey(), $record->getKey());
 
-        $response = $this->actingAs($user)
+        $response = $this
+            ->actingAs($user)
             ->get(cp_route('runway.edit', [
                 'resourceHandle' => 'post',
                 'record' => $post->id,
@@ -380,7 +390,8 @@ class ResourceControllerTest extends TestCase
 
         $this->assertEquals($post->getKey(), $record->getKey());
 
-        $response = $this->actingAs($user)
+        $response = $this
+            ->actingAs($user)
             ->get(cp_route('runway.edit', [
                 'resourceHandle' => 'post',
                 'record' => $post->id,
@@ -404,18 +415,19 @@ class ResourceControllerTest extends TestCase
     {
         $post = Post::factory()->create([
             'values' => [
-                'alt_title' => $this->faker->words(6, asText: true),
+                'alt_title' => "Im Toby Ziegler, and I work at the White House.",
             ],
         ]);
 
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
             ->assertSee($post->body)
-            ->assertSee($post->values['alt_title']);
+            ->assertSee("Im Toby Ziegler, and I work at the White House.");
     }
 
     /** @test */
@@ -428,7 +440,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
@@ -441,7 +454,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
@@ -467,7 +481,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
@@ -495,7 +510,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
@@ -515,7 +531,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
@@ -542,7 +559,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
@@ -569,7 +587,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
@@ -596,7 +615,8 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',

--- a/tests/Http/Controllers/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/ResourceListingControllerTest.php
@@ -51,8 +51,8 @@ class ResourceListingControllerTest extends TestCase
     /** @test */
     public function listing_rows_are_ordered_as_per_config()
     {
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.order_by', 'id');
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.order_by_direction', 'desc');
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post.order_by', 'id');
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post.order_by_direction', 'desc');
 
         Runway::discoverResources();
 
@@ -105,7 +105,7 @@ class ResourceListingControllerTest extends TestCase
     /** @test */
     public function can_search_records_with_has_many_relationship()
     {
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.blueprint.sections.main.fields', [
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.blueprint.sections.main.fields', [
             [
                 'handle' => 'name',
                 'field' => [

--- a/tests/Http/Controllers/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/ResourceListingControllerTest.php
@@ -18,9 +18,8 @@ class ResourceListingControllerTest extends TestCase
     /** @test */
     public function user_with_no_permissions_cannot_access_resource_listing()
     {
-        $user = User::make()->save();
-
-        $this->actingAs($user)
+        $this
+            ->actingAs(User::make()->save())
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
             ->assertRedirect();
     }
@@ -29,22 +28,22 @@ class ResourceListingControllerTest extends TestCase
     public function can_sort_listing_rows()
     {
         $user = User::make()->makeSuper()->save();
-
         $posts = Post::factory()->count(2)->create();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
             ->assertOk()
             ->assertJson([
                 'data' => [
                     [
                         'title' => $posts[0]->title,
-                        'edit_url' => 'http://localhost/cp/runway/post/'.$posts[0]->id,
+                        'edit_url' => "http://localhost/cp/runway/post/{$posts[0]->id}",
                         'id' => $posts[0]->id,
                     ],
                     [
                         'title' => $posts[1]->title,
-                        'edit_url' => 'http://localhost/cp/runway/post/'.$posts[1]->id,
+                        'edit_url' => "http://localhost/cp/runway/post/{$posts[1]->id}",
                         'id' => $posts[1]->id,
                     ],
                 ],
@@ -60,22 +59,22 @@ class ResourceListingControllerTest extends TestCase
         Runway::discoverResources();
 
         $user = User::make()->makeSuper()->save();
-
         $posts = Post::factory()->count(2)->create();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
             ->assertOk()
             ->assertJson([
                 'data' => [
                     [
                         'title' => $posts[1]->title,
-                        'edit_url' => 'http://localhost/cp/runway/post/'.$posts[1]->id,
+                        'edit_url' => "http://localhost/cp/runway/post/{$posts[1]->id}",
                         'id' => $posts[1]->id,
                     ],
                     [
                         'title' => $posts[0]->title,
-                        'edit_url' => 'http://localhost/cp/runway/post/'.$posts[0]->id,
+                        'edit_url' => "http://localhost/cp/runway/post/{$posts[0]->id}",
                         'id' => $posts[0]->id,
                     ],
                 ],
@@ -86,19 +85,19 @@ class ResourceListingControllerTest extends TestCase
     public function can_search()
     {
         $user = User::make()->makeSuper()->save();
-
         $posts = Post::factory()->count(2)->create();
 
         $posts[0]->update(['title' => 'Apple Pie']);
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post', 'search' => 'Apple']))
             ->assertOk()
             ->assertJson([
                 'data' => [
                     [
                         'title' => $posts[0]->title,
-                        'edit_url' => 'http://localhost/cp/runway/post/'.$posts[0]->id,
+                        'edit_url' => "http://localhost/cp/runway/post/{$posts[0]->id}",
                         'id' => $posts[0]->id,
                     ],
                 ],
@@ -128,10 +127,10 @@ class ResourceListingControllerTest extends TestCase
         Runway::discoverResources();
 
         $user = User::make()->makeSuper()->save();
-
         $author = Author::factory()->withPosts()->create(['name' => 'Colin The Caterpillar']);
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.listing-api', [
                 'resourceHandle' => 'author',
                 'search' => 'Colin',
@@ -142,7 +141,7 @@ class ResourceListingControllerTest extends TestCase
                 'data' => [
                     [
                         'name' => 'Colin The Caterpillar',
-                        'edit_url' => 'http://localhost/cp/runway/author/'.$author->id,
+                        'edit_url' => "http://localhost/cp/runway/author/{$author->id}",
                         'id' => $author->id,
                     ],
                 ],
@@ -155,7 +154,8 @@ class ResourceListingControllerTest extends TestCase
         Post::factory()->count(15)->create();
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']).'?perPage=5')
             ->assertOk()
             ->assertJson([
@@ -181,7 +181,8 @@ class ResourceListingControllerTest extends TestCase
 
         $user = User::make()->makeSuper()->save();
 
-        $this->actingAs($user)
+        $this
+            ->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']).'?columns=title,values->alt_title')
             ->assertOk()
             ->assertSee($posts[0]->values['alt_title'])

--- a/tests/Http/Controllers/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/ResourceListingControllerTest.php
@@ -3,14 +3,17 @@
 namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
 
 use DoubleThreeDigital\Runway\Runway;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\User;
 
 class ResourceListingControllerTest extends TestCase
 {
-    use RefreshDatabase;
+    use RefreshDatabase, WithFaker;
 
     /** @test */
     public function user_with_no_permissions_cannot_access_resource_listing()
@@ -27,7 +30,7 @@ class ResourceListingControllerTest extends TestCase
     {
         $user = User::make()->makeSuper()->save();
 
-        $posts = $this->postFactory(2);
+        $posts = Post::factory()->count(2)->create();
 
         $this->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
@@ -58,7 +61,7 @@ class ResourceListingControllerTest extends TestCase
 
         $user = User::make()->makeSuper()->save();
 
-        $posts = $this->postFactory(2);
+        $posts = Post::factory()->count(2)->create();
 
         $this->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
@@ -84,7 +87,7 @@ class ResourceListingControllerTest extends TestCase
     {
         $user = User::make()->makeSuper()->save();
 
-        $posts = $this->postFactory(2);
+        $posts = Post::factory()->count(2)->create();
 
         $posts[0]->update(['title' => 'Apple Pie']);
 
@@ -126,9 +129,7 @@ class ResourceListingControllerTest extends TestCase
 
         $user = User::make()->makeSuper()->save();
 
-        $author = $this->authorFactory(1, ['name' => 'Colin The Caterpillar']);
-
-        $posts = $this->postFactory(5, ['author_id' => $author->id]);
+        $author = Author::factory()->withPosts()->create(['name' => 'Colin The Caterpillar']);
 
         $this->actingAs($user)
             ->get(cp_route('runway.listing-api', [
@@ -151,9 +152,8 @@ class ResourceListingControllerTest extends TestCase
     /** @test */
     public function can_paginate_results()
     {
+        Post::factory()->count(15)->create();
         $user = User::make()->makeSuper()->save();
-
-        $posts = $this->postFactory(15);
 
         $this->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']).'?perPage=5')
@@ -173,13 +173,13 @@ class ResourceListingControllerTest extends TestCase
      */
     public function can_get_values_from_nested_fields()
     {
-        $user = User::make()->makeSuper()->save();
-
-        $posts = $this->postFactory(3, [
+        $posts = Post::factory()->count(3)->create([
             'values' => [
                 'alt_title' => $this->faker()->words(6, true),
             ],
         ]);
+
+        $user = User::make()->makeSuper()->save();
 
         $this->actingAs($user)
             ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']).'?columns=title,values->alt_title')

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -81,7 +81,7 @@ class ResourceTest extends TestCase
 
         $singular = $resource->singular();
 
-        $this->assertSame($singular, 'Post');
+        $this->assertEquals($singular, 'Post');
     }
 
     /** @test */
@@ -95,7 +95,7 @@ class ResourceTest extends TestCase
 
         $singular = $resource->singular();
 
-        $this->assertSame($singular, 'Bibliothek');
+        $this->assertEquals($singular, 'Bibliothek');
     }
 
     /** @test */
@@ -107,7 +107,7 @@ class ResourceTest extends TestCase
 
         $plural = $resource->plural();
 
-        $this->assertSame($plural, 'Posts');
+        $this->assertEquals($plural, 'Posts');
     }
 
     /** @test */
@@ -121,6 +121,6 @@ class ResourceTest extends TestCase
 
         $plural = $resource->plural();
 
-        $this->assertSame($plural, 'Bibliotheken');
+        $this->assertEquals($plural, 'Bibliotheken');
     }
 }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -22,7 +22,7 @@ class ResourceTest extends TestCase
     /** @test */
     public function can_get_eager_loading_relations_for_has_many_field()
     {
-        $fields = Config::get('runway.resources.DoubleThreeDigital\Runway\Tests\Author.blueprint.sections.main.fields');
+        $fields = Config::get('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.blueprint.sections.main.fields');
 
         $fields[] = [
             'handle' => 'posts',
@@ -34,7 +34,7 @@ class ResourceTest extends TestCase
             ],
         ];
 
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Author.blueprint.sections.main.fields', $fields);
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.blueprint.sections.main.fields', $fields);
 
         Runway::discoverResources();
 
@@ -60,7 +60,7 @@ class ResourceTest extends TestCase
     /** @test */
     public function can_get_eager_loading_relations_as_defined_in_config()
     {
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.with', ['author']);
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post.with', ['author']);
 
         Runway::discoverResources();
 
@@ -87,7 +87,7 @@ class ResourceTest extends TestCase
     /** @test */
     public function can_get_configured_singular()
     {
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.singular', 'Bibliothek');
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post.singular', 'Bibliothek');
 
         Runway::discoverResources();
 
@@ -113,7 +113,7 @@ class ResourceTest extends TestCase
     /** @test */
     public function can_get_configured_plural()
     {
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.plural', 'Bibliotheken');
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post.plural', 'Bibliotheken');
 
         Runway::discoverResources();
 

--- a/tests/Routing/FrontendRoutingTest.php
+++ b/tests/Routing/FrontendRoutingTest.php
@@ -4,13 +4,10 @@ namespace DoubleThreeDigital\Runway\Tests\Routing;
 
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Config;
 
 class FrontendRoutingTest extends TestCase
 {
-    use WithFaker;
-
     /** @test */
     public function returns_resource_response_for_resource()
     {
@@ -33,7 +30,7 @@ class FrontendRoutingTest extends TestCase
     {
         $post = Post::factory()->create([
             'values' => [
-                'alt_title' => $this->faker->words(6, asText: true),
+                'alt_title' => 'Alternative Title...',
             ],
         ]);
 
@@ -42,7 +39,7 @@ class FrontendRoutingTest extends TestCase
         $this
             ->get($runwayUri->uri)
             ->assertOk()
-            ->assertSee($post->values['alt_title'])
+            ->assertSee('Alternative Title...')
             ->assertSee('TEMPLATE: default')
             ->assertSee('LAYOUT: layout');
     }

--- a/tests/Routing/FrontendRoutingTest.php
+++ b/tests/Routing/FrontendRoutingTest.php
@@ -4,14 +4,17 @@ namespace DoubleThreeDigital\Runway\Tests\Routing;
 
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Config;
 
 class FrontendRoutingTest extends TestCase
 {
+    use WithFaker;
+
     /** @test */
     public function returns_resource_response_for_resource()
     {
-        $post = $this->postFactory();
+        $post = Post::factory()->create();
         $runwayUri = $post->fresh()->runwayUri;
 
         $this
@@ -28,13 +31,11 @@ class FrontendRoutingTest extends TestCase
      */
     public function returns_resource_response_for_resource_with_nested_field()
     {
-        $post = $this->postFactory(
-            attributes: [
-                'values' => [
-                    'alt_title' => $this->faker->words(6, asText: true),
-                ],
+        $post = Post::factory()->create([
+            'values' => [
+                'alt_title' => $this->faker->words(6, asText: true),
             ],
-        );
+        ]);
 
         $runwayUri = $post->fresh()->runwayUri;
 
@@ -54,7 +55,7 @@ class FrontendRoutingTest extends TestCase
         // TODO: find way of mocking the template & rebooting Runway's resources
         Config::set('runway.resources.'.Post::class.'.template', 'custom');
 
-        $post = $this->postFactory();
+        $post = Post::factory()->create();
         $runwayUri = $post->fresh()->runwayUri;
 
         $this
@@ -73,7 +74,7 @@ class FrontendRoutingTest extends TestCase
         // TODO: find way of mocking the template & rebooting Runway's resources
         Config::set('runway.resources.'.Post::class.'.layout', 'blog-layout');
 
-        $post = $this->postFactory();
+        $post = Post::factory()->create();
         $runwayUri = $post->fresh()->runwayUri;
 
         $this

--- a/tests/Routing/FrontendRoutingTest.php
+++ b/tests/Routing/FrontendRoutingTest.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Tests\Routing;
 
+use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
@@ -47,10 +48,9 @@ class FrontendRoutingTest extends TestCase
     /** @test */
     public function returns_resource_response_for_resource_with_custom_template()
     {
-        $this->markTestIncomplete();
-
-        // TODO: find way of mocking the template & rebooting Runway's resources
         Config::set('runway.resources.'.Post::class.'.template', 'custom');
+
+        Runway::discoverResources();
 
         $post = Post::factory()->create();
         $runwayUri = $post->fresh()->runwayUri;
@@ -66,10 +66,9 @@ class FrontendRoutingTest extends TestCase
     /** @test */
     public function returns_resource_response_for_resource_with_custom_layout()
     {
-        $this->markTestIncomplete();
-
-        // TODO: find way of mocking the template & rebooting Runway's resources
         Config::set('runway.resources.'.Post::class.'.layout', 'blog-layout');
+
+        Runway::discoverResources();
 
         $post = Post::factory()->create();
         $runwayUri = $post->fresh()->runwayUri;

--- a/tests/Routing/FrontendRoutingTest.php
+++ b/tests/Routing/FrontendRoutingTest.php
@@ -2,7 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Tests\Routing;
 
-use DoubleThreeDigital\Runway\Tests\Post;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 

--- a/tests/Routing/ResourceRoutingRepositoryTest.php
+++ b/tests/Routing/ResourceRoutingRepositoryTest.php
@@ -14,11 +14,11 @@ class ResourceRoutingRepositoryTest extends TestCase
         $post = $this->postFactory();
         $runwayUri = $post->fresh()->runwayUri;
 
-        $this->assertSame($runwayUri->uri, "/posts/{$post->slug}");
+        $this->assertEquals($runwayUri->uri, "/posts/{$post->slug}");
 
         $findByUri = Data::findByUri("/posts/{$post->slug}");
 
-        $this->assertSame($post->fresh()->id, $findByUri->id);
+        $this->assertEquals($post->fresh()->id, $findByUri->id);
         $this->assertTrue($findByUri instanceof RoutingModel);
     }
 
@@ -31,7 +31,7 @@ class ResourceRoutingRepositoryTest extends TestCase
 
         $findByUri = Data::findByUri("/posts/{$posts[0]->slug}");
 
-        $this->assertSame($posts[0]->id, $findByUri->id);
+        $this->assertEquals($posts[0]->id, $findByUri->id);
         $this->assertTrue($findByUri instanceof RoutingModel);
     }
 
@@ -49,7 +49,7 @@ class ResourceRoutingRepositoryTest extends TestCase
         $post = $this->postFactory();
         $runwayUri = $post->fresh()->runwayUri;
 
-        $this->assertSame($runwayUri->uri, "/posts/{$post->slug}");
+        $this->assertEquals($runwayUri->uri, "/posts/{$post->slug}");
 
         $findByUri = Data::findByUri("/posts/{$post->slug}-smth");
 

--- a/tests/Routing/ResourceRoutingRepositoryTest.php
+++ b/tests/Routing/ResourceRoutingRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\Runway\Tests\Routing;
 
 use DoubleThreeDigital\Runway\Routing\RoutingModel;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Statamic\Facades\Data;
 
@@ -11,7 +12,7 @@ class ResourceRoutingRepositoryTest extends TestCase
     /** @test */
     public function can_find_by_uri()
     {
-        $post = $this->postFactory();
+        $post = Post::factory()->create();
         $runwayUri = $post->fresh()->runwayUri;
 
         $this->assertEquals($runwayUri->uri, "/posts/{$post->slug}");
@@ -25,9 +26,7 @@ class ResourceRoutingRepositoryTest extends TestCase
     /** @test */
     public function can_find_by_uri_where_multiple_matches_are_found()
     {
-        $posts = $this->postFactory(5, [
-            'slug' => 'chicken-fried-rice',
-        ]);
+        $posts = Post::factory()->count(5)->create(['slug' => 'chicken-fried-rice']);
 
         $findByUri = Data::findByUri("/posts/{$posts[0]->slug}");
 
@@ -46,7 +45,7 @@ class ResourceRoutingRepositoryTest extends TestCase
     /** @test */
     public function cant_find_by_uri_if_a_similar_uri_exists()
     {
-        $post = $this->postFactory();
+        $post = Post::factory()->create();
         $runwayUri = $post->fresh()->runwayUri;
 
         $this->assertEquals($runwayUri->uri, "/posts/{$post->slug}");

--- a/tests/RunwayTest.php
+++ b/tests/RunwayTest.php
@@ -21,12 +21,12 @@ class RunwayTest extends TestCase
         $this->assertCount(2, $all);
 
         $this->assertTrue($all->first() instanceof Resource);
-        $this->assertSame('post', $all->first()->handle());
+        $this->assertEquals('post', $all->first()->handle());
         $this->assertTrue($all->first()->model() instanceof Model);
         $this->assertTrue($all->first()->blueprint() instanceof Blueprint);
 
         $this->assertTrue($all->last() instanceof Resource);
-        $this->assertSame('author', $all->last()->handle());
+        $this->assertEquals('author', $all->last()->handle());
         $this->assertTrue($all->last()->model() instanceof Model);
         $this->assertTrue($all->last()->blueprint() instanceof Blueprint);
     }
@@ -39,7 +39,7 @@ class RunwayTest extends TestCase
         $find = Runway::findResource('author');
 
         $this->assertTrue($find instanceof Resource);
-        $this->assertSame('author', $find->handle());
+        $this->assertEquals('author', $find->handle());
         $this->assertTrue($find->model() instanceof Model);
         $this->assertTrue($find->blueprint() instanceof Blueprint);
     }

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\Runway\Tests\Tags;
 
 use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Tags\RunwayTag;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
@@ -32,7 +33,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_no_parameters()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $this->tag->setParameters([]);
         $usage = $this->tag->wildcard('post');
@@ -49,7 +50,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_select_parameter()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $this->tag->setParameters([
             'select' => 'id,title,slug',
@@ -83,7 +84,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_scope_parameter()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $posts[0]->update(['title' => 'Pasta']);
         $posts[2]->update(['title' => 'Apple']);
@@ -104,7 +105,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_scope_parameter_and_scope_arguments()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $posts[0]->update(['title' => 'Pasta']);
         $posts[2]->update(['title' => 'Apple']);
@@ -127,7 +128,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_scope_parameter_and_scope_arguments_and_multiple_scopes()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $posts[0]->update(['title' => 'Pasta']);
         $posts[2]->update(['title' => 'Apple']);
@@ -150,7 +151,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_where_parameter()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $posts[0]->update(['title' => 'penguin']);
 
@@ -167,8 +168,8 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_where_parameter_when_condition_is_on_relationship_field()
     {
-        $posts = $this->postFactory(5);
-        $author = $this->authorFactory();
+        $posts = Post::factory()->count(5)->create();
+        $author = Author::factory()->create();
 
         $posts[0]->update(['author_id' => $author->id]);
         $posts[2]->update(['author_id' => $author->id]);
@@ -189,7 +190,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_with_parameter()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $posts[0]->update(['title' => 'tiger']);
 
@@ -209,7 +210,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_sort_parameter()
     {
-        $posts = $this->postFactory(2);
+        $posts = Post::factory()->count(2)->create();
 
         $posts[0]->update(['title' => 'abc']);
         $posts[1]->update(['title' => 'def']);
@@ -229,7 +230,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_scoping()
     {
-        $posts = $this->postFactory(2);
+        $posts = Post::factory()->count(2)->create();
 
         $posts[0]->update(['title' => 'abc']);
         $posts[1]->update(['title' => 'def']);
@@ -249,7 +250,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_limit_parameter()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $this->tag->setParameters([
             'limit' => 2,
@@ -268,7 +269,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_with_scoping_and_pagination()
     {
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $this->tag->setParameters([
             'limit' => 2,
@@ -291,7 +292,7 @@ class RunwayTagTest extends TestCase
     /** @test */
     public function can_get_records_and_non_blueprint_columns_are_returned()
     {
-        $posts = $this->postFactory(2);
+        $posts = Post::factory()->count(2)->create();
 
         $this->tag->setParameters([]);
 
@@ -313,7 +314,7 @@ class RunwayTagTest extends TestCase
 
         Runway::discoverResources();
 
-        $posts = $this->postFactory(5);
+        $posts = Post::factory()->count(5)->create();
 
         $this->tag->setParameters([]);
         $usage = $this->tag->wildcard('blog_posts');

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -4,7 +4,7 @@ namespace DoubleThreeDigital\Runway\Tests\Tags;
 
 use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Tags\RunwayTag;
-use DoubleThreeDigital\Runway\Tests\Post;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Support\Facades\Config;
 use Statamic\Facades\Antlers;

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -37,13 +37,13 @@ class RunwayTagTest extends TestCase
         $this->tag->setParameters([]);
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(5, count($usage));
+        $this->assertEquals(5, count($usage));
 
-        $this->assertSame((string) $usage[0]['title'], $posts[0]->title);
-        $this->assertSame((string) $usage[1]['title'], $posts[1]->title);
-        $this->assertSame((string) $usage[2]['title'], $posts[2]->title);
-        $this->assertSame((string) $usage[3]['title'], $posts[3]->title);
-        $this->assertSame((string) $usage[4]['title'], $posts[4]->title);
+        $this->assertEquals((string) $usage[0]['title'], $posts[0]->title);
+        $this->assertEquals((string) $usage[1]['title'], $posts[1]->title);
+        $this->assertEquals((string) $usage[2]['title'], $posts[2]->title);
+        $this->assertEquals((string) $usage[3]['title'], $posts[3]->title);
+        $this->assertEquals((string) $usage[4]['title'], $posts[4]->title);
     }
 
     /** @test */
@@ -57,26 +57,26 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(5, count($usage));
+        $this->assertEquals(5, count($usage));
 
-        $this->assertSame((string) $usage[0]['title']->value(), $posts[0]->title);
-        $this->assertSame((string) $usage[0]['slug']->value(), $posts[0]->slug);
+        $this->assertEquals((string) $usage[0]['title']->value(), $posts[0]->title);
+        $this->assertEquals((string) $usage[0]['slug']->value(), $posts[0]->slug);
         $this->assertEmpty((string) $usage[0]['body']->value());
 
-        $this->assertSame((string) $usage[1]['title']->value(), $posts[1]->title);
-        $this->assertSame((string) $usage[1]['slug']->value(), $posts[1]->slug);
+        $this->assertEquals((string) $usage[1]['title']->value(), $posts[1]->title);
+        $this->assertEquals((string) $usage[1]['slug']->value(), $posts[1]->slug);
         $this->assertEmpty((string) $usage[1]['body']->value());
 
-        $this->assertSame((string) $usage[2]['title']->value(), $posts[2]->title);
-        $this->assertSame((string) $usage[2]['slug']->value(), $posts[2]->slug);
+        $this->assertEquals((string) $usage[2]['title']->value(), $posts[2]->title);
+        $this->assertEquals((string) $usage[2]['slug']->value(), $posts[2]->slug);
         $this->assertEmpty((string) $usage[2]['body']->value());
 
-        $this->assertSame((string) $usage[3]['title']->value(), $posts[3]->title);
-        $this->assertSame((string) $usage[3]['slug']->value(), $posts[3]->slug);
+        $this->assertEquals((string) $usage[3]['title']->value(), $posts[3]->title);
+        $this->assertEquals((string) $usage[3]['slug']->value(), $posts[3]->slug);
         $this->assertEmpty((string) $usage[3]['body']->value());
 
-        $this->assertSame((string) $usage[4]['title']->value(), $posts[4]->title);
-        $this->assertSame((string) $usage[4]['slug']->value(), $posts[4]->slug);
+        $this->assertEquals((string) $usage[4]['title']->value(), $posts[4]->title);
+        $this->assertEquals((string) $usage[4]['slug']->value(), $posts[4]->slug);
         $this->assertEmpty((string) $usage[4]['body']->value());
     }
 
@@ -95,10 +95,10 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(3, count($usage));
-        $this->assertSame((string) $usage[0]['title']->value(), 'Pasta');
-        $this->assertSame((string) $usage[1]['title']->value(), 'Apple');
-        $this->assertSame((string) $usage[2]['title']->value(), 'Burger');
+        $this->assertEquals(3, count($usage));
+        $this->assertEquals((string) $usage[0]['title']->value(), 'Pasta');
+        $this->assertEquals((string) $usage[1]['title']->value(), 'Apple');
+        $this->assertEquals((string) $usage[2]['title']->value(), 'Burger');
     }
 
     /** @test */
@@ -120,8 +120,8 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(1, count($usage));
-        $this->assertSame((string) $usage[0]['title']->value(), 'Apple');
+        $this->assertEquals(1, count($usage));
+        $this->assertEquals((string) $usage[0]['title']->value(), 'Apple');
     }
 
     /** @test */
@@ -143,8 +143,8 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(1, count($usage));
-        $this->assertSame((string) $usage[0]['title']->value(), 'Apple');
+        $this->assertEquals(1, count($usage));
+        $this->assertEquals((string) $usage[0]['title']->value(), 'Apple');
     }
 
     /** @test */
@@ -160,8 +160,8 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(1, count($usage));
-        $this->assertSame((string) $usage[0]['title']->value(), 'penguin');
+        $this->assertEquals(1, count($usage));
+        $this->assertEquals((string) $usage[0]['title']->value(), 'penguin');
     }
 
     /** @test */
@@ -180,10 +180,10 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(3, count($usage));
-        $this->assertSame((string) $usage[0]['title']->value(), $posts[0]->title);
-        $this->assertSame((string) $usage[1]['title']->value(), $posts[2]->title);
-        $this->assertSame((string) $usage[2]['title']->value(), $posts[3]->title);
+        $this->assertEquals(3, count($usage));
+        $this->assertEquals((string) $usage[0]['title']->value(), $posts[0]->title);
+        $this->assertEquals((string) $usage[1]['title']->value(), $posts[2]->title);
+        $this->assertEquals((string) $usage[2]['title']->value(), $posts[3]->title);
     }
 
     /** @test */
@@ -199,11 +199,11 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(5, count($usage));
-        $this->assertSame((string) $usage[0]['title'], 'tiger');
+        $this->assertEquals(5, count($usage));
+        $this->assertEquals((string) $usage[0]['title'], 'tiger');
 
         $this->assertInstanceOf(Value::class, $usage[0]['author']);
-        $this->assertSame($usage[0]['author']->value()['name']->value(), $posts[0]->author->name);
+        $this->assertEquals($usage[0]['author']->value()['name']->value(), $posts[0]->author->name);
     }
 
     /** @test */
@@ -220,10 +220,10 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(2, count($usage));
+        $this->assertEquals(2, count($usage));
 
-        $this->assertSame((string) $usage[0]['title'], 'def');
-        $this->assertSame((string) $usage[1]['title'], 'abc');
+        $this->assertEquals((string) $usage[0]['title'], 'def');
+        $this->assertEquals((string) $usage[1]['title'], 'abc');
     }
 
     /** @test */
@@ -240,10 +240,10 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(2, count($usage['items']));
+        $this->assertEquals(2, count($usage['items']));
 
-        $this->assertSame((string) $usage['items'][0]['title'], 'abc');
-        $this->assertSame((string) $usage['items'][1]['title'], 'def');
+        $this->assertEquals((string) $usage['items'][0]['title'], 'abc');
+        $this->assertEquals((string) $usage['items'][1]['title'], 'def');
     }
 
     /** @test */
@@ -257,10 +257,10 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(2, count($usage));
+        $this->assertEquals(2, count($usage));
 
-        $this->assertSame((string) $usage[0]['title'], $posts[0]['title']);
-        $this->assertSame((string) $usage[1]['title'], $posts[1]['title']);
+        $this->assertEquals((string) $usage[0]['title'], $posts[0]['title']);
+        $this->assertEquals((string) $usage[1]['title'], $posts[1]['title']);
 
         $this->assertFalse(isset($usage[2]));
     }
@@ -277,10 +277,10 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(2, count($usage['items']));
+        $this->assertEquals(2, count($usage['items']));
 
-        $this->assertSame((string) $usage['items'][0]['title'], $posts[0]['title']);
-        $this->assertSame((string) $usage['items'][1]['title'], $posts[1]['title']);
+        $this->assertEquals((string) $usage['items'][0]['title'], $posts[0]['title']);
+        $this->assertEquals((string) $usage['items'][1]['title'], $posts[1]['title']);
 
         $this->assertFalse(isset($usage['items'][2]));
 
@@ -297,13 +297,13 @@ class RunwayTagTest extends TestCase
 
         $usage = $this->tag->wildcard('post');
 
-        $this->assertSame(2, count($usage));
+        $this->assertEquals(2, count($usage));
 
-        $this->assertSame($usage[0]['id']->value(), $posts[0]['id']);
-        $this->assertSame($usage[1]['id']->value(), $posts[1]['id']);
+        $this->assertEquals($usage[0]['id']->value(), $posts[0]['id']);
+        $this->assertEquals($usage[1]['id']->value(), $posts[1]['id']);
 
-        $this->assertSame((string) $usage[0]['title']->value(), $posts[0]['title']);
-        $this->assertSame((string) $usage[1]['title']->value(), $posts[1]['title']);
+        $this->assertEquals((string) $usage[0]['title']->value(), $posts[0]['title']);
+        $this->assertEquals((string) $usage[1]['title']->value(), $posts[1]['title']);
     }
 
     /** @test */
@@ -318,12 +318,12 @@ class RunwayTagTest extends TestCase
         $this->tag->setParameters([]);
         $usage = $this->tag->wildcard('blog_posts');
 
-        $this->assertSame(5, count($usage));
+        $this->assertEquals(5, count($usage));
 
-        $this->assertSame((string) $usage[0]['title'], $posts[0]->title);
-        $this->assertSame((string) $usage[1]['title'], $posts[1]->title);
-        $this->assertSame((string) $usage[2]['title'], $posts[2]->title);
-        $this->assertSame((string) $usage[3]['title'], $posts[3]->title);
-        $this->assertSame((string) $usage[4]['title'], $posts[4]->title);
+        $this->assertEquals((string) $usage[0]['title'], $posts[0]->title);
+        $this->assertEquals((string) $usage[1]['title'], $posts[1]->title);
+        $this->assertEquals((string) $usage[2]['title'], $posts[2]->title);
+        $this->assertEquals((string) $usage[3]['title'], $posts[3]->title);
+        $this->assertEquals((string) $usage[4]['title'], $posts[4]->title);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,9 @@
 
 namespace DoubleThreeDigital\Runway\Tests;
 
-use DoubleThreeDigital\Runway\Routing\Traits\RunwayRoutes;
 use DoubleThreeDigital\Runway\ServiceProvider;
-use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
-use Illuminate\Database\Eloquent\Model;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use Illuminate\Encryption\Encrypter;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -101,143 +100,7 @@ abstract class TestCase extends OrchestraTestCase
             __DIR__.'/__fixtures__/resources/views',
         ]);
 
-        $app['config']->set('runway', [
-            'resources' => [
-                Post::class => [
-                    'name' => 'Posts',
-                    'blueprint' => [
-                        'sections' => [
-                            'main' => [
-                                'fields' => [
-                                    [
-                                        'handle' => 'title',
-                                        'field' => [
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'slug',
-                                        'field' => [
-                                            'type' => 'slug',
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'body',
-                                        'field' => [
-                                            'type' => 'textarea',
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'values->alt_title',
-                                        'field' => [
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'values->alt_body',
-                                        'field' => [
-                                            'type' => 'markdown',
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'excerpt',
-                                        'field' => [
-                                            'type' => 'textarea',
-                                            'read_only' => true,
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'author_id',
-                                        'field' => [
-                                            'type' => 'belongs_to',
-                                            'resource' => 'author',
-                                            'max_items' => 1,
-                                            'mode' => 'default',
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'age',
-                                        'field' => [
-                                            'type' => 'integer',
-                                            'visibility' => 'computed',
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'start_date',
-                                        'field' => [
-                                            'type' => 'date',
-                                            'time_enabled' => true,
-                                            'validate' => [
-                                                'before:end_date',
-                                            ],
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'end_date',
-                                        'field' => [
-                                            'type' => 'date',
-                                            'time_enabled' => true,
-                                        ],
-                                    ],
-                                    [
-                                        'handle' => 'dont_save',
-                                        'field' => [
-                                            'type' => 'text',
-                                            'save' => false,
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                    'listing' => [
-                        'columns' => [
-                            'title',
-                        ],
-                        'sort' => [
-                            'column' => 'title',
-                            'direction' => 'desc',
-                        ],
-                    ],
-                    'route' => '/posts/{{ slug }}',
-                ],
-
-                Author::class => [
-                    'name' => 'Author',
-                    'blueprint' => [
-                        'sections' => [
-                            'main' => [
-                                'fields' => [
-                                    [
-                                        'handle' => 'name',
-                                        'field' => [
-                                            'type' => 'text',
-                                        ],
-                                    ],
-                                    // [
-                                    //     'handle' => 'posts',
-                                    //     'field' => [
-                                    //         'type' => 'has_many',
-                                    //         'resource' => 'post',
-                                    //         'mode' => 'select',
-                                    //     ],
-                                    // ],
-                                ],
-                            ],
-                        ],
-                    ],
-                    'listing' => [
-                        'columns' => [
-                            'name',
-                        ],
-                        'sort' => [
-                            'column' => 'name',
-                            'direction' => 'asc',
-                        ],
-                    ],
-                ],
-            ],
-        ]);
+        $app['config']->set('runway', require(__DIR__.'/__fixtures__/config/runway.php'));
     }
 
     public function postFactory(int $count = 1, array $attributes = [])
@@ -271,63 +134,5 @@ abstract class TestCase extends OrchestraTestCase
         return count($items) === 1
             ? $items[0]
             : $items;
-    }
-}
-
-class Post extends Model
-{
-    use HasRunwayResource, RunwayRoutes;
-
-    protected $fillable = [
-        'title', 'slug', 'body', 'values', 'author_id', 'sort_order',
-    ];
-
-    protected $appends = [
-        'excerpt',
-    ];
-
-    protected $casts = [
-        'values' => 'array',
-    ];
-
-    public function scopeFood($query)
-    {
-        $query->whereIn('title', ['Pasta', 'Apple', 'Burger']);
-    }
-
-    public function scopeFruit($query, $smth)
-    {
-        if ($smth === 'idoo') {
-            $query->whereIn('title', ['Apple']);
-        }
-    }
-
-    public function author()
-    {
-        return $this->belongsTo(Author::class);
-    }
-
-    public function getExcerptAttribute()
-    {
-        return 'This is an excerpt.';
-    }
-}
-
-class Author extends Model
-{
-    use HasRunwayResource;
-
-    protected $fillable = [
-        'name', 'start_date', 'end_date',
-    ];
-
-    public function posts()
-    {
-        return $this->hasMany(Post::class);
-    }
-
-    public function pivottedPosts()
-    {
-        return $this->belongsToMany(Post::class, 'post_author');
     }
 }

--- a/tests/UpdateScripts/ChangePermissionNamesTest.php
+++ b/tests/UpdateScripts/ChangePermissionNamesTest.php
@@ -2,7 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Tests\UpdateScripts;
 
-use DoubleThreeDigital\Runway\Tests\Helpers\RunsUpdateScripts;
+use DoubleThreeDigital\Runway\Tests\UpdateScripts\RunsUpdateScripts;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use DoubleThreeDigital\Runway\UpdateScripts\ChangePermissionNames;
 use Illuminate\Support\Facades\File;

--- a/tests/UpdateScripts/ChangePermissionNamesTest.php
+++ b/tests/UpdateScripts/ChangePermissionNamesTest.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Tests\UpdateScripts;
 
-use DoubleThreeDigital\Runway\Tests\UpdateScripts\RunsUpdateScripts;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use DoubleThreeDigital\Runway\UpdateScripts\ChangePermissionNames;
 use Illuminate\Support\Facades\File;

--- a/tests/UpdateScripts/RunsUpdateScripts.php
+++ b/tests/UpdateScripts/RunsUpdateScripts.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Tests\Helpers;
+namespace DoubleThreeDigital\Runway\Tests\UpdateScripts;
 
 trait RunsUpdateScripts
 {

--- a/tests/__fixtures__/app/Models/Author.php
+++ b/tests/__fixtures__/app/Models/Author.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests\Fixtures\Models;
+
+use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
+use Illuminate\Database\Eloquent\Model;
+
+class Author extends Model
+{
+    use HasRunwayResource;
+
+    protected $fillable = [
+        'name', 'start_date', 'end_date',
+    ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+
+    public function pivottedPosts()
+    {
+        return $this->belongsToMany(Post::class, 'post_author');
+    }
+}

--- a/tests/__fixtures__/app/Models/Author.php
+++ b/tests/__fixtures__/app/Models/Author.php
@@ -2,12 +2,14 @@
 
 namespace DoubleThreeDigital\Runway\Tests\Fixtures\Models;
 
+use DoubleThreeDigital\Runway\Tests\Fixtures\Database\Factories\AuthorFactory;
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Author extends Model
 {
-    use HasRunwayResource;
+    use HasFactory, HasRunwayResource;
 
     protected $fillable = [
         'name', 'start_date', 'end_date',
@@ -21,5 +23,10 @@ class Author extends Model
     public function pivottedPosts()
     {
         return $this->belongsToMany(Post::class, 'post_author');
+    }
+
+    protected static function newFactory()
+    {
+        return AuthorFactory::new();
     }
 }

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests\Fixtures\Models;
+
+use DoubleThreeDigital\Runway\Routing\Traits\RunwayRoutes;
+use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasRunwayResource, RunwayRoutes;
+
+    protected $fillable = [
+        'title', 'slug', 'body', 'values', 'author_id', 'sort_order',
+    ];
+
+    protected $appends = [
+        'excerpt',
+    ];
+
+    protected $casts = [
+        'values' => 'array',
+    ];
+
+    public function scopeFood($query)
+    {
+        $query->whereIn('title', ['Pasta', 'Apple', 'Burger']);
+    }
+
+    public function scopeFruit($query, $smth)
+    {
+        if ($smth === 'idoo') {
+            $query->whereIn('title', ['Apple']);
+        }
+    }
+
+    public function author()
+    {
+        return $this->belongsTo(Author::class);
+    }
+
+    public function getExcerptAttribute()
+    {
+        return 'This is an excerpt.';
+    }
+}

--- a/tests/__fixtures__/app/Models/Post.php
+++ b/tests/__fixtures__/app/Models/Post.php
@@ -3,12 +3,14 @@
 namespace DoubleThreeDigital\Runway\Tests\Fixtures\Models;
 
 use DoubleThreeDigital\Runway\Routing\Traits\RunwayRoutes;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Database\Factories\PostFactory;
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
-    use HasRunwayResource, RunwayRoutes;
+    use HasFactory, HasRunwayResource, RunwayRoutes;
 
     protected $fillable = [
         'title', 'slug', 'body', 'values', 'author_id', 'sort_order',
@@ -42,5 +44,10 @@ class Post extends Model
     public function getExcerptAttribute()
     {
         return 'This is an excerpt.';
+    }
+
+    protected static function newFactory()
+    {
+        return PostFactory::new();
     }
 }

--- a/tests/__fixtures__/config/runway.php
+++ b/tests/__fixtures__/config/runway.php
@@ -1,0 +1,142 @@
+<?php
+
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
+
+return [
+    'resources' => [
+        Post::class => [
+            'name' => 'Posts',
+            'blueprint' => [
+                'sections' => [
+                    'main' => [
+                        'fields' => [
+                            [
+                                'handle' => 'title',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'handle' => 'slug',
+                                'field' => [
+                                    'type' => 'slug',
+                                ],
+                            ],
+                            [
+                                'handle' => 'body',
+                                'field' => [
+                                    'type' => 'textarea',
+                                ],
+                            ],
+                            [
+                                'handle' => 'values->alt_title',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            [
+                                'handle' => 'values->alt_body',
+                                'field' => [
+                                    'type' => 'markdown',
+                                ],
+                            ],
+                            [
+                                'handle' => 'excerpt',
+                                'field' => [
+                                    'type' => 'textarea',
+                                    'read_only' => true,
+                                ],
+                            ],
+                            [
+                                'handle' => 'author_id',
+                                'field' => [
+                                    'type' => 'belongs_to',
+                                    'resource' => 'author',
+                                    'max_items' => 1,
+                                    'mode' => 'default',
+                                ],
+                            ],
+                            [
+                                'handle' => 'age',
+                                'field' => [
+                                    'type' => 'integer',
+                                    'visibility' => 'computed',
+                                ],
+                            ],
+                            [
+                                'handle' => 'start_date',
+                                'field' => [
+                                    'type' => 'date',
+                                    'time_enabled' => true,
+                                    'validate' => [
+                                        'before:end_date',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'handle' => 'end_date',
+                                'field' => [
+                                    'type' => 'date',
+                                    'time_enabled' => true,
+                                ],
+                            ],
+                            [
+                                'handle' => 'dont_save',
+                                'field' => [
+                                    'type' => 'text',
+                                    'save' => false,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'listing' => [
+                'columns' => [
+                    'title',
+                ],
+                'sort' => [
+                    'column' => 'title',
+                    'direction' => 'desc',
+                ],
+            ],
+            'route' => '/posts/{{ slug }}',
+        ],
+
+        Author::class => [
+            'name' => 'Author',
+            'blueprint' => [
+                'sections' => [
+                    'main' => [
+                        'fields' => [
+                            [
+                                'handle' => 'name',
+                                'field' => [
+                                    'type' => 'text',
+                                ],
+                            ],
+                            // [
+                            //     'handle' => 'posts',
+                            //     'field' => [
+                            //         'type' => 'has_many',
+                            //         'resource' => 'post',
+                            //         'mode' => 'select',
+                            //     ],
+                            // ],
+                        ],
+                    ],
+                ],
+            ],
+            'listing' => [
+                'columns' => [
+                    'name',
+                ],
+                'sort' => [
+                    'column' => 'name',
+                    'direction' => 'asc',
+                ],
+            ],
+        ],
+    ],
+];

--- a/tests/__fixtures__/database/factories/AuthorFactory.php
+++ b/tests/__fixtures__/database/factories/AuthorFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests\Fixtures\Database\Factories;
+
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AuthorFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Author::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+        ];
+    }
+
+    public function withPosts(int $count = 1): Factory
+    {
+        return $this->afterCreating(function (Author $author) use ($count) {
+            $author->posts()->createMany(
+                PostFactory::new()->count($count)->make()->toArray()
+            );
+        });
+    }
+}

--- a/tests/__fixtures__/database/factories/PostFactory.php
+++ b/tests/__fixtures__/database/factories/PostFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests\Fixtures\Database\Factories;
+
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PostFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Post::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $title = implode(' ', $this->faker->words(6)),
+            'slug' => str_slug($title),
+            'body' => implode(' ', $this->faker->paragraphs(10)),
+            'author_id' => Author::factory()->create()->id,
+        ];
+    }
+}


### PR DESCRIPTION
This pull request tidies up the Runway test suite in preparation for v6 development.

Some of the changes:

- Moved the Eloquent models out of the `TestCase` file and into their own files.
- Moved the Runway config out of the `TestCase` file and into its own file.
- Replaced the previous `postFactory` and `authorFactory` methods with model factories
- Swapped out `assertSame` for `assertEquals` (dunno why, I like equals right now 🤷‍♂️ )
- Removed a PHPUnit warning that complained about "tests with no assertions"