### PR TITLE
[6.x] Refactor how we get blueprint fields

### DIFF
--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -119,7 +119,7 @@ class BaseFieldtype extends Relationship
 
         $items
             ->transform(function ($record) use ($resource) {
-                return collect($resource->listableColumns())
+                return $resource->listableColumns()
                     ->mapWithKeys(function ($columnKey) use ($record) {
                         $value = $record->{$columnKey};
 
@@ -316,7 +316,7 @@ class BaseFieldtype extends Relationship
         $resource = Runway::findResource($this->config('resource'));
         $blueprint = $resource->blueprint();
 
-        return collect($resource->listableColumns())
+        return $resource->listableColumns()
             ->map(function ($columnKey, $index) use ($blueprint) {
                 /** @var \Statamic\Fields\Field $field */
                 $blueprintField = $blueprint->field($columnKey);

--- a/src/Http/Controllers/Traits/HasListingColumns.php
+++ b/src/Http/Controllers/Traits/HasListingColumns.php
@@ -8,7 +8,7 @@ trait HasListingColumns
 {
     protected function buildColumns(Resource $resource, $blueprint)
     {
-        return collect($resource->listableColumns())
+        return $resource->listableColumns()
             ->map(function ($columnKey) use ($blueprint) {
                 $field = $blueprint->field($columnKey);
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -218,7 +218,7 @@ class Resource
     {
         return $this
             ->fluentlyGetOrSet('titleField')
-            ->getter(fn ($field) => $field ?? $this->listableColumns()[0])
+            ->getter(fn ($field) => $field ?? $this->listableColumns()->first())
             ->args(func_get_args());
     }
 
@@ -268,13 +268,12 @@ class Resource
             ->args(func_get_args());
     }
 
-    public function listableColumns(): array
+    public function listableColumns(): Collection
     {
         return $this->blueprint()->fields()->all()
             ->filter(fn (Field $field) => $field->isVisibleOnListing())
             ->map->handle()
-            ->values()
-            ->toArray();
+            ->values();
     }
 
     public function hasRouting(): bool

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -2,11 +2,13 @@
 
 namespace DoubleThreeDigital\Runway;
 
+use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Statamic\Fields\Blueprint;
+use Statamic\Fields\Field;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
 class Resource
@@ -229,40 +231,36 @@ class Resource
         return $this->fluentlyGetOrSet('eagerLoadingRelations')
             ->getter(function ($eagerLoadingRelations) {
                 if (! $eagerLoadingRelations) {
-                    return $this->blueprint()->fields()->items()
-                        ->filter(function ($field) {
-                            $type = $field['field']['type'] ?? null;
-
-                            return $type === 'belongs_to'
-                                || $type === 'has_many';
+                    return $this->blueprint()->fields()->all()
+                        ->filter(function (Field $field) {
+                            return $field->fieldtype() instanceof BelongsToFieldtype
+                                || $field->fieldtype() instanceof \DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;
                         })
-                        ->mapWithKeys(function ($field) {
-                            $relationName = $field['handle'];
+                        ->mapWithKeys(function (Field $field) {
+                            $eloquentRelationship = $field->handle();
 
                             // If the field has a `relationship_name` config key, use that instead.
                             // Sometimes a column name will be different to the relationship name
                             // (the method on the model) so our magic won't be able to figure out what's what.
                             // Eg. standard_parent_id -> parent
-                            if (isset($field['field']['relationship_name'])) {
-                                $relationName = $field['field']['relationship_name'];
+                            if ($field->get('relationship_name')) {
+                                $eloquentRelationship = $field->get('relationship_name');
                             }
 
                             // If field handle is `author_id`, strip off the `_id`
-                            if (str_contains($relationName, '_id')) {
-                                $relationName = Str::replaceLast('_id', '', $relationName);
+                            if (str_contains($eloquentRelationship, '_id')) {
+                                $eloquentRelationship = Str::replaceLast('_id', '', $eloquentRelationship);
                             }
 
                             // If field handle contains an underscore, convert the name to camel case
-                            if (str_contains($relationName, '_')) {
-                                $relationName = Str::camel($relationName);
+                            if (str_contains($eloquentRelationship, '_')) {
+                                $eloquentRelationship = Str::camel($eloquentRelationship);
                             }
 
-                            return [
-                                $field['handle'] => $relationName,
-                            ];
+                            return [$field->handle() => $eloquentRelationship];
                         })
                         ->merge(['runwayUri'])
-                        ->filter(fn ($relationName) => method_exists($this->model(), $relationName));
+                        ->filter(fn ($eloquentRelationship) => method_exists($this->model(), $eloquentRelationship));
                 }
 
                 return collect($eagerLoadingRelations);
@@ -270,18 +268,12 @@ class Resource
             ->args(func_get_args());
     }
 
-    /**
-     * Returns an array of column handles that are marked as listable.
-     */
     public function listableColumns(): array
     {
-        return $this->blueprint()->fields()->items()
-            ->reject(function ($field) {
-                return isset($field['import'])
-                    || (isset($field['field']['listable']) && $field['field']['listable'] === 'hidden')
-                    || (isset($field['field']['listable']) && $field['field']['listable'] === false);
-            })
-            ->pluck('handle')
+        return $this->blueprint()->fields()->all()
+            ->filter(fn (Field $field) => $field->isVisibleOnListing())
+            ->map->handle()
+            ->values()
             ->toArray();
     }
 

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\Runway\Tests\Fieldtypes;
 
 use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;
+use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post;
 use DoubleThreeDigital\Runway\Tests\TestCase;
 use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -97,6 +98,23 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertEquals($getIndexItems->all()[0]['title'], 'Scully');
         $this->assertEquals($getIndexItems->all()[1]['title'], 'Jake Peralta');
         $this->assertEquals($getIndexItems->all()[2]['title'], 'Amy Santiago');
+    }
+
+    /** @test */
+    public function can_get_index_items_and_search()
+    {
+        Author::factory()->count(10)->create();
+        $hasselhoff = Author::factory()->create(['name' => 'David Hasselhoff']);
+
+        $getIndexItems = $this->fieldtype->getIndexItems(
+            new FilteredRequest(['search' => 'hasselhoff'])
+        );
+
+        $this->assertIsObject($getIndexItems);
+        $this->assertTrue($getIndexItems instanceof Paginator);
+        $this->assertEquals($getIndexItems->count(), 1);
+
+        $this->assertEquals($getIndexItems->first()['id'], $hasselhoff->id);
     }
 
     /** @test */

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -124,9 +124,9 @@ class HasManyFieldtypeTest extends TestCase
 
         Runway::discoverResources();
 
-        $postA = Post::factory()->create(['title' => 'Arnold A']);
-        $postB = Post::factory()->create(['title' => 'Richard B']);
-        $postC = Post::factory()->create(['title' => 'Graham C']);
+        Post::factory()->create(['title' => 'Arnold A']);
+        Post::factory()->create(['title' => 'Richard B']);
+        Post::factory()->create(['title' => 'Graham C']);
 
         $getIndexItems = $this->fieldtype->getIndexItems(new FilteredRequest(['paginate' => false]));
 

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -156,6 +156,6 @@ class ResourceTest extends TestCase
             'summary',
             'seo_title',
             'seo_description',
-        ], $resource->listableColumns());
+        ], $resource->listableColumns()->toArray());
     }
 }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -4,6 +4,7 @@ namespace DoubleThreeDigital\Runway\Tests;
 
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Support\Facades\Config;
+use Statamic\Facades\Fieldset;
 
 class ResourceTest extends TestCase
 {
@@ -122,5 +123,39 @@ class ResourceTest extends TestCase
         $plural = $resource->plural();
 
         $this->assertEquals($plural, 'Bibliotheken');
+    }
+
+    /** @test */
+    public function can_get_listable_columns()
+    {
+        Fieldset::make('seo')->setContents([
+            'fields' => [
+                ['handle' => 'seo_title', 'field' => ['type' => 'text', 'listable' => true]],
+                ['handle' => 'seo_description', 'field' => ['type' => 'textarea', 'listable' => true]],
+            ],
+        ])->save();
+
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post.blueprint', [
+            'sections' => [
+                'main' => [
+                    'fields' => [
+                        ['handle' => 'title', 'field' => ['type' => 'text', 'listable' => true]],
+                        ['handle' => 'summary', 'field' => ['type' => 'textarea', 'listable' => true]],
+                        ['handle' => 'body', 'field' => ['type' => 'markdown', 'listable' => 'hidden']],
+                        ['handle' => 'thumbnail', 'field' => ['type' => 'assets', 'listable' => false]],
+                        ['import' => 'seo']
+                    ],
+                ],
+            ],
+        ]);
+
+        $resource = Runway::discoverResources()->findResource('post');
+
+        $this->assertEquals([
+            'title',
+            'summary',
+            'seo_title',
+            'seo_description',
+        ], $resource->listableColumns());
     }
 }

--- a/tests/__fixtures__/config/runway.php
+++ b/tests/__fixtures__/config/runway.php
@@ -15,6 +15,7 @@ return [
                                 'handle' => 'title',
                                 'field' => [
                                     'type' => 'text',
+                                    'listable' => true,
                                 ],
                             ],
                             [
@@ -114,6 +115,7 @@ return [
                                 'handle' => 'name',
                                 'field' => [
                                     'type' => 'text',
+                                    'listable' => true,
                                 ],
                             ],
                             // [


### PR DESCRIPTION
This pull request refactors Runway gets fields from a resource's blueprint.

Previously, Runway used the `$blueprint->fields()->items()` method which returned arrays for each of the fields. The `items` method also meant fields imported from fieldsets weren't returned.

Now, with this PR, Runway uses the `$blueprint->fields()->all()` method which means we can take advantage of the `Field` object and include any fields imported from fieldsets. 