### PR TITLE
[6.x] Refactor listing queries & use route binding for resources

### DIFF
--- a/resources/views/create.blade.php
+++ b/resources/views/create.blade.php
@@ -17,7 +17,7 @@
         :is-creating="true"
         publish-container="base"
         :resource='@json($resource->toArray())'
-        create-another-url="{{ cp_route('runway.create', ['resourceHandle' => $resource->handle()]) }}"
-        listing-url="{{ cp_route('runway.index', ['resourceHandle' => $resource->handle()]) }}"
+        create-another-url="{{ cp_route('runway.create', ['resource' => $resource->handle()]) }}"
+        listing-url="{{ cp_route('runway.index', ['resource' => $resource->handle()]) }}"
     ></runway-publish-form>
 @endsection

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -19,8 +19,8 @@
         publish-container="base"
         :read-only="{{ $resource->readOnly() ? 'true' : 'false' }}"
         :resource='@json($resource->toArray())'
-        create-another-url="{{ cp_route('runway.create', ['resourceHandle' => $resource->handle()]) }}"
-        listing-url="{{ cp_route('runway.index', ['resourceHandle' => $resource->handle()]) }}"
+        create-another-url="{{ cp_route('runway.create', ['resource' => $resource->handle()]) }}"
+        listing-url="{{ cp_route('runway.index', ['resource' => $resource->handle()]) }}"
     ></runway-publish-form>
 
     <script>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -10,7 +10,7 @@
             @can('create', $resource)
                 <a
                     class="btn-primary"
-                    href="{{ cp_route('runway.create', ['resourceHandle' => $resource->handle()]) }}"
+                    href="{{ cp_route('runway.create', ['resource' => $resource->handle()]) }}"
                 >
                     {{ __('Create :resource', [
                         'resource' => $resource->singular()

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -6,14 +6,14 @@ use DoubleThreeDigital\Runway\Http\Controllers\ResourceListingController;
 use Illuminate\Support\Facades\Route;
 
 Route::name('runway.')->prefix('runway')->group(function () {
-    Route::get('/{resourceHandle}', [ResourceController::class, 'index'])->name('index');
+    Route::get('/{resource}', [ResourceController::class, 'index'])->name('index');
 
-    Route::get('/{resourceHandle}/listing-api', [ResourceListingController::class, 'index'])->name('listing-api');
-    Route::post('/{resourceHandle}/actions', [ResourceActionController::class, 'runAction'])->name('actions.run');
-    Route::post('/{resourceHandle}/actions/list', [ResourceActionController::class, 'bulkActionsList'])->name('actions.bulk');
+    Route::get('/{resource}/listing-api', [ResourceListingController::class, 'index'])->name('listing-api');
+    Route::post('/{resource}/actions', [ResourceActionController::class, 'runAction'])->name('actions.run');
+    Route::post('/{resource}/actions/list', [ResourceActionController::class, 'bulkActionsList'])->name('actions.bulk');
 
-    Route::get('/{resourceHandle}/create', [ResourceController::class, 'create'])->name('create');
-    Route::post('/{resourceHandle}/create', [ResourceController::class, 'store'])->name('store');
-    Route::get('/{resourceHandle}/{record}', [ResourceController::class, 'edit'])->name('edit');
-    Route::patch('/{resourceHandle}/{record}', [ResourceController::class, 'update'])->name('update');
+    Route::get('/{resource}/create', [ResourceController::class, 'create'])->name('create');
+    Route::post('/{resource}/create', [ResourceController::class, 'store'])->name('store');
+    Route::get('/{resource}/{record}', [ResourceController::class, 'edit'])->name('edit');
+    Route::patch('/{resource}/{record}', [ResourceController::class, 'update'])->name('update');
 });

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -13,8 +13,6 @@ use Illuminate\Support\Collection;
 use Statamic\CP\Column;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Parse;
-use Statamic\Fields\Field;
-use Statamic\Fieldtypes\Hidden;
 use Statamic\Fieldtypes\Relationship;
 
 class BaseFieldtype extends Relationship

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -162,7 +162,7 @@ class BaseFieldtype extends Relationship
             }
 
             $url = cp_route('runway.edit', [
-                'resourceHandle' => $resource->handle(),
+                'resource' => $resource->handle(),
                 'record' => $record->{$resource->routeKey()},
             ]);
 
@@ -332,7 +332,7 @@ class BaseFieldtype extends Relationship
         }
 
         $editUrl = cp_route('runway.edit', [
-            'resourceHandle' => $resource->handle(),
+            'resource' => $resource->handle(),
             'record' => $record->{$resource->routeKey()},
         ]);
 
@@ -351,7 +351,7 @@ class BaseFieldtype extends Relationship
             [
                 'title' => $resource->singular(),
                 'url' => cp_route('runway.create', [
-                    'resourceHandle' => $resource->handle(),
+                    'resource' => $resource->handle(),
                 ]),
             ],
         ];

--- a/src/Fieldtypes/HasManyFieldtype.php
+++ b/src/Fieldtypes/HasManyFieldtype.php
@@ -54,7 +54,7 @@ class HasManyFieldtype extends BaseFieldtype
         $resource = Runway::findResource($this->config('resource'));
 
         // Determine whether or not this field is on a resource or a collection
-        $resourceHandle = request()->route('resourceHandle');
+        $resourceHandle = request()->route('resource');
 
         if (! $resourceHandle) {
             return $data;
@@ -69,7 +69,7 @@ class HasManyFieldtype extends BaseFieldtype
     public function process($data)
     {
         // Determine whether or not this field is on a resource or a collection
-        $resourceHandle = request()->route('resourceHandle') ?? Blink::get('RunwayRouteResource');
+        $resourceHandle = request()->route('resource') ?? Blink::get('RunwayRouteResource');
 
         if (! $resourceHandle) {
             return $data;
@@ -170,7 +170,7 @@ class HasManyFieldtype extends BaseFieldtype
     {
         return array_merge(parent::preload(), [
             'actionUrl' => cp_route('runway.actions.run', [
-                'resourceHandle' => $this->config('resource'),
+                'resource' => $this->config('resource'),
             ]),
         ]);
     }

--- a/src/Http/Controllers/ResourceActionController.php
+++ b/src/Http/Controllers/ResourceActionController.php
@@ -2,6 +2,7 @@
 
 namespace DoubleThreeDigital\Runway\Http\Controllers;
 
+use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Http\Request;
 use Statamic\Http\Controllers\CP\ActionController;
@@ -10,16 +11,16 @@ class ResourceActionController extends ActionController
 {
     protected $resource;
 
-    public function runAction(Request $request, $resourceHandle)
+    public function runAction(Request $request, Resource $resource)
     {
-        $this->resource = Runway::findResource($resourceHandle);
+        $this->resource = $resource;
 
         return parent::run($request);
     }
 
-    public function bulkActionsList(Request $request, $resourceHandle)
+    public function bulkActionsList(Request $request, Resource $resource)
     {
-        $this->resource = Runway::findResource($resourceHandle);
+        $this->resource = $resource;
 
         return parent::bulkActions($request);
     }

--- a/src/Http/Controllers/ResourceActionController.php
+++ b/src/Http/Controllers/ResourceActionController.php
@@ -3,7 +3,6 @@
 namespace DoubleThreeDigital\Runway\Http\Controllers;
 
 use DoubleThreeDigital\Runway\Resource;
-use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Http\Request;
 use Statamic\Http\Controllers\CP\ActionController;
 

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -3,6 +3,7 @@
 namespace DoubleThreeDigital\Runway\Http\Controllers;
 
 use DoubleThreeDigital\Runway\Http\Resources\ResourceCollection;
+use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
 use Statamic\Facades\User;
 use Statamic\Fields\Field;
@@ -14,9 +15,8 @@ class ResourceListingController extends CpController
 {
     use QueriesFilters, Traits\HasListingColumns;
 
-    public function index(FilteredRequest $request, $resourceHandle)
+    public function index(FilteredRequest $request, Resource $resource)
     {
-        $resource = Runway::findResource($resourceHandle);
         $blueprint = $resource->blueprint();
 
         if (! User::current()->can('view', $resource)) {
@@ -34,15 +34,15 @@ class ResourceListingController extends CpController
         $query->when($request->search, fn ($query) => $query->runwaySearch($request->search));
 
         $activeFilterBadges = $this->queryFilters($query, $request->filters, [
-            'resource' => $resourceHandle,
+            'resource' => $resource->handle(),
             'blueprints' => [$blueprint],
         ]);
 
         $results = $query->paginate($request->input('perPage', config('statamic.cp.pagination_size')));
 
         return (new ResourceCollection($results))
-            ->setResourceHandle($resourceHandle)
-            ->setColumnPreferenceKey('runway.'.$resourceHandle.'.columns')
+            ->setResourceHandle($resource->handle())
+            ->setColumnPreferenceKey("runway.{$resource->handle()}.columns")
             ->setColumns($this->buildColumns($resource, $blueprint))
             ->additional([
                 'meta' => [

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -4,9 +4,7 @@ namespace DoubleThreeDigital\Runway\Http\Controllers;
 
 use DoubleThreeDigital\Runway\Http\Resources\ResourceCollection;
 use DoubleThreeDigital\Runway\Resource;
-use DoubleThreeDigital\Runway\Runway;
 use Statamic\Facades\User;
-use Statamic\Fields\Field;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;

--- a/src/Http/Requests/CreateRequest.php
+++ b/src/Http/Requests/CreateRequest.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Http\Requests;
 
-use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
 

--- a/src/Http/Requests/CreateRequest.php
+++ b/src/Http/Requests/CreateRequest.php
@@ -10,7 +10,7 @@ class CreateRequest extends FormRequest
 {
     public function authorize()
     {
-        $resource = Runway::findResource($this->resourceHandle);
+        $resource = $this->route('resource');
 
         if ($resource->readOnly()) {
             return false;

--- a/src/Http/Requests/EditRequest.php
+++ b/src/Http/Requests/EditRequest.php
@@ -10,7 +10,7 @@ class EditRequest extends FormRequest
 {
     public function authorize()
     {
-        $resource = Runway::findResource($this->resourceHandle);
+        $resource = $this->route('resource');
 
         return User::current()->can('edit', $resource);
     }

--- a/src/Http/Requests/EditRequest.php
+++ b/src/Http/Requests/EditRequest.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Http\Requests;
 
-use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
 

--- a/src/Http/Requests/IndexRequest.php
+++ b/src/Http/Requests/IndexRequest.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Http\Requests;
 
-use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
 

--- a/src/Http/Requests/IndexRequest.php
+++ b/src/Http/Requests/IndexRequest.php
@@ -10,7 +10,7 @@ class IndexRequest extends FormRequest
 {
     public function authorize()
     {
-        $resource = Runway::findResource($this->resourceHandle);
+        $resource = $this->route('resource');
 
         return User::current()->can('view', $resource);
     }

--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Http\Requests;
 
-use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
 

--- a/src/Http/Requests/StoreRequest.php
+++ b/src/Http/Requests/StoreRequest.php
@@ -10,7 +10,7 @@ class StoreRequest extends FormRequest
 {
     public function authorize()
     {
-        $resource = Runway::findResource($this->resourceHandle);
+        $resource = $this->route('resource');
 
         if ($resource->readOnly()) {
             return false;

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Http\Requests;
 
-use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
 

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -10,7 +10,7 @@ class UpdateRequest extends FormRequest
 {
     public function authorize()
     {
-        $resource = Runway::findResource($this->resourceHandle);
+        $resource = $this->route('resource');
 
         if ($resource->readOnly()) {
             return false;

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -94,7 +94,7 @@ class ResourceCollection extends LaravelResourceCollection
                 }
 
                 $row['id'] = $record->getKey();
-                $row['edit_url'] = cp_route('runway.edit', ['resourceHandle' => $handle, 'record' => $record->getRouteKey()]);
+                $row['edit_url'] = cp_route('runway.edit', ['resource' => $handle, 'record' => $record->getRouteKey()]);
                 $row['permalink'] = $this->runwayResource->hasRouting() ? $record->uri() : null;
                 $row['editable'] = User::current()->can('edit', $this->runwayResource);
                 $row['viewable'] = User::current()->can('view', $this->runwayResource);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -7,6 +7,7 @@ use DoubleThreeDigital\Runway\Search\Provider as SearchProvider;
 use DoubleThreeDigital\Runway\Search\Searchable;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Traits\Conditionable;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\GraphQL;
@@ -76,6 +77,7 @@ class ServiceProvider extends AddonServiceProvider
         Statamic::booted(function () {
             Runway::discoverResources();
 
+            $this->registerRouteBindings();
             $this->registerPermissions();
             $this->registerPolicies();
             $this->registerNavigation();
@@ -88,6 +90,13 @@ class ServiceProvider extends AddonServiceProvider
                 $this->app->get(\Statamic\Contracts\Data\DataRepository::class)
                     ->setRepository('runway-resources', Routing\ResourceRoutingRepository::class);
             });
+        });
+    }
+
+    protected function registerRouteBindings()
+    {
+        Route::bind('resource', function ($value) {
+            return Runway::findResource($value);
         });
     }
 
@@ -126,7 +135,7 @@ class ServiceProvider extends AddonServiceProvider
                     $nav->create($resource->name())
                         ->section(__('Content'))
                         ->icon($resource->cpIcon())
-                        ->route('runway.index', ['resourceHandle' => $resource->handle()])
+                        ->route('runway.index', ['resource' => $resource->handle()])
                         ->can('view', $resource);
                 });
         });

--- a/src/Traits/HasRunwayResource.php
+++ b/src/Traits/HasRunwayResource.php
@@ -4,9 +4,14 @@ namespace DoubleThreeDigital\Runway\Traits;
 
 use DoubleThreeDigital\Runway\Data\AugmentedModel;
 use DoubleThreeDigital\Runway\Data\HasAugmentedInstance;
+use DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Statamic\Contracts\Data\Augmented;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Hidden;
+use Statamic\Fieldtypes\Section;
 use Statamic\GraphQL\ResolvesValues;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
@@ -25,5 +30,17 @@ trait HasRunwayResource
     public function runwayResource(): Resource
     {
         return Runway::findResourceByModel($this);
+    }
+
+    public function scopeRunwaySearch(Builder $query, string $searchQuery)
+    {
+        $this->runwayResource()->blueprint()->fields()->all()
+            ->reject(function (Field $field) {
+                return $field->fieldtype() instanceof HasManyFieldtype
+                    || $field->fieldtype() instanceof Hidden
+                    || $field->fieldtype() instanceof Section
+                    || $field->visibility() === 'computed';
+            })
+            ->each(fn (Field $field) => $query->orWhere($field->handle(), 'LIKE', '%'.$searchQuery.'%'));
     }
 }

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -19,7 +19,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.index', ['resourceHandle' => 'post']))
+            ->get(cp_route('runway.index', ['resource' => 'post']))
             ->assertOk()
             ->assertViewIs('runway::index')
             ->assertSee([
@@ -35,7 +35,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.create', ['resourceHandle' => 'post']))
+            ->get(cp_route('runway.create', ['resource' => 'post']))
             ->assertOk();
     }
 
@@ -50,7 +50,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.create', ['resourceHandle' => 'post']))
+            ->get(cp_route('runway.create', ['resource' => 'post']))
             ->assertRedirect();
     }
 
@@ -62,7 +62,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+            ->post(cp_route('runway.store', ['resource' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -90,7 +90,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+            ->post(cp_route('runway.store', ['resource' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -114,7 +114,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+            ->post(cp_route('runway.store', ['resource' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -142,7 +142,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+            ->post(cp_route('runway.store', ['resource' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -170,7 +170,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+            ->post(cp_route('runway.store', ['resource' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -198,7 +198,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+            ->post(cp_route('runway.store', ['resource' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -226,7 +226,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->post(cp_route('runway.store', ['resourceHandle' => 'post']), [
+            ->post(cp_route('runway.store', ['resource' => 'post']), [
                 'title' => 'Jingle Bells',
                 'slug' => 'jingle-bells',
                 'body' => 'Jingle Bells, Jingle Bells, jingle all the way...',
@@ -255,7 +255,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
             ->assertSee($post->body);
@@ -268,7 +268,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => 12345]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => 12345]))
             ->assertNotFound()
             ->assertSee('Page Not Found');
     }
@@ -303,7 +303,7 @@ class ResourceControllerTest extends TestCase
         $response = $this
             ->actingAs($user)
             ->get(cp_route('runway.edit', [
-                'resourceHandle' => 'post',
+                'resource' => 'post',
                 'record' => $post->id,
             ]))
             ->assertOk();
@@ -348,7 +348,7 @@ class ResourceControllerTest extends TestCase
         $response = $this
             ->actingAs($user)
             ->get(cp_route('runway.edit', [
-                'resourceHandle' => 'post',
+                'resource' => 'post',
                 'record' => $post->id,
             ]))
             ->assertOk();
@@ -393,7 +393,7 @@ class ResourceControllerTest extends TestCase
         $response = $this
             ->actingAs($user)
             ->get(cp_route('runway.edit', [
-                'resourceHandle' => 'post',
+                'resource' => 'post',
                 'record' => $post->id,
             ]))
             ->assertOk();
@@ -423,7 +423,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
             ->assertSee($post->body)
@@ -442,7 +442,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.edit', ['resourceHandle' => 'post', 'record' => $post->id]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
             ->assertSee($post->body);
@@ -456,7 +456,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -483,7 +483,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -512,7 +512,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -533,7 +533,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -561,7 +561,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -589,7 +589,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -617,7 +617,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resourceHandle' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,

--- a/tests/Http/Controllers/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/ResourceListingControllerTest.php
@@ -20,7 +20,7 @@ class ResourceListingControllerTest extends TestCase
     {
         $this
             ->actingAs(User::make()->save())
-            ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
+            ->get(cp_route('runway.listing-api', ['resource' => 'post']))
             ->assertRedirect();
     }
 
@@ -32,7 +32,7 @@ class ResourceListingControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
+            ->get(cp_route('runway.listing-api', ['resource' => 'post']))
             ->assertOk()
             ->assertJson([
                 'data' => [
@@ -63,7 +63,7 @@ class ResourceListingControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']))
+            ->get(cp_route('runway.listing-api', ['resource' => 'post']))
             ->assertOk()
             ->assertJson([
                 'data' => [
@@ -91,7 +91,7 @@ class ResourceListingControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post', 'search' => 'Apple']))
+            ->get(cp_route('runway.listing-api', ['resource' => 'post', 'search' => 'Apple']))
             ->assertOk()
             ->assertJson([
                 'data' => [
@@ -132,7 +132,7 @@ class ResourceListingControllerTest extends TestCase
         $this
             ->actingAs($user)
             ->get(cp_route('runway.listing-api', [
-                'resourceHandle' => 'author',
+                'resource' => 'author',
                 'search' => 'Colin',
                 'columns' => 'name,posts',
             ]))
@@ -156,7 +156,7 @@ class ResourceListingControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']).'?perPage=5')
+            ->get(cp_route('runway.listing-api', ['resource' => 'post']).'?perPage=5')
             ->assertOk()
             ->assertJson([
                 'meta' => [
@@ -183,7 +183,7 @@ class ResourceListingControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.listing-api', ['resourceHandle' => 'post']).'?columns=title,values->alt_title')
+            ->get(cp_route('runway.listing-api', ['resource' => 'post']).'?columns=title,values->alt_title')
             ->assertOk()
             ->assertSee($posts[0]->values['alt_title'])
             ->assertSee($posts[1]->values['alt_title'])


### PR DESCRIPTION
This pull request makes two changes:

* It refactors the search query used in Runway's listing tables to use a query scope (which can be over-ridden, if needed).
* Configures route binding for resources