### PR TITLE
[6.x] PHP 8.3 Support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.1]
+        php: [8.3, 8.2, 8.1]
         laravel: [10.*]
         statamic: [^4.0]
         testbench: [8.*]


### PR DESCRIPTION
This pull request adds support for PHP 8.3, due to be released on the [23rd November](https://stitcher.io/blog/new-in-php-83).