### PR TITLE
[6.x] Rename `eagerLoadingRelations` method

### DIFF
--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -80,7 +80,7 @@ class AugmentedModel extends AbstractAugmented
 
     protected function eloquentRelationships()
     {
-        return $this->resource->eagerLoadingRelations();
+        return $this->resource->eloquentRelationships();
     }
 
     protected function getFromData($handle)
@@ -96,8 +96,8 @@ class AugmentedModel extends AbstractAugmented
     {
         $fields = $this->blueprintFields();
 
-        if ($this->resource->eagerLoadingRelations()->flip()->has($handle)) {
-            $relatedField = $this->resource->eagerLoadingRelations()->flip()->get($handle);
+        if ($this->resource->eloquentRelationships()->flip()->has($handle)) {
+            $relatedField = $this->resource->eloquentRelationships()->flip()->get($handle);
 
             return new Value(
                 $value,

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -214,9 +214,9 @@ class BaseFieldtype extends Relationship
             })
             ->map(function ($record) use ($resource) {
                 if (! $record instanceof Model) {
-                    $eagerLoadingRelations = collect($this->config('with') ?? [])->join(',');
+                    $eagerLoadingRelationships = collect($this->config('with') ?? [])->join(',');
 
-                    $record = Blink::once("Runway::{$this->config('resource')}::{$record}}::{$eagerLoadingRelations}", function () use ($resource, $record) {
+                    $record = Blink::once("Runway::{$this->config('resource')}::{$record}}::{$eagerLoadingRelationships}", function () use ($resource, $record) {
                         return $resource->model()
                             ->when($this->config('with'), function ($query) {
                                 $query->with(Arr::wrap($this->config('with')));

--- a/src/GraphQL/ResourceIndexQuery.php
+++ b/src/GraphQL/ResourceIndexQuery.php
@@ -39,7 +39,7 @@ class ResourceIndexQuery extends Query
     {
         $query = $this->resource->model()
             ->newQuery()
-            ->with($this->resource->eagerLoadingRelations()->values()->all());
+            ->with($this->resource->eloquentRelationships()->values()->all());
 
         $this->filterQuery($query, $args['filter'] ?? []);
         $this->sortQuery($query, $args['sort'] ?? []);

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -207,7 +207,7 @@ class ResourceController extends CpController
 
                 $column = $relatedResource->titleField();
 
-                $relationshipName = $resource->eagerLoadingRelations()->get($field->handle()) ?? $field->handle();
+                $relationshipName = $resource->eloquentRelationships()->get($field->handle()) ?? $field->handle();
 
                 $model->{$field->handle()} = $model->{$relationshipName}()
                     ->select($relatedResource->model()->qualifyColumn($relatedResource->primaryKey()), $column)

--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -2,7 +2,6 @@
 
 namespace DoubleThreeDigital\Runway\Http\Controllers;
 
-use Carbon\CarbonInterface;
 use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
 use DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;
 use DoubleThreeDigital\Runway\Http\Requests\CreateRequest;
@@ -12,12 +11,10 @@ use DoubleThreeDigital\Runway\Http\Requests\StoreRequest;
 use DoubleThreeDigital\Runway\Http\Requests\UpdateRequest;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
-use DoubleThreeDigital\Runway\Support\Json;
 use Illuminate\Database\Eloquent\Model;
 use Statamic\CP\Breadcrumbs;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Scope;
-use Statamic\Facades\User;
 use Statamic\Fields\Field;
 use Statamic\Http\Controllers\CP\CpController;
 

--- a/src/Http/Controllers/ResourceListingController.php
+++ b/src/Http/Controllers/ResourceListingController.php
@@ -25,7 +25,7 @@ class ResourceListingController extends CpController
         $sortDirection = $request->input('order', $resource->orderByDirection());
 
         $query = $resource->model()
-            ->with($resource->eagerLoadingRelations()->values()->all())
+            ->with($resource->eloquentRelationships()->values()->all())
             ->orderBy($sortField, $sortDirection);
 
         $query->when($query->hasNamedScope('runwayListing'), fn ($query) => $query->runwayListing());

--- a/src/Http/Controllers/Traits/PreparesModels.php
+++ b/src/Http/Controllers/Traits/PreparesModels.php
@@ -22,7 +22,7 @@ trait PreparesModels
         $blueprint = $resource->blueprint();
 
         return $blueprint->fields()->all()
-            ->mapWithKeys(function (Field $field) use ($model, $blueprint) {
+            ->mapWithKeys(function (Field $field) use ($model) {
                 $value = data_get($model, Str::replace('->', '.', $field->handle()));
 
                 // When $value is a Carbon instance, format it it with the format defined in the blueprint.

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -68,7 +68,7 @@ class ResourceCollection extends LaravelResourceCollection
                         // If we've eager loaded in relationships, just pass in the model
                         // instance. We can prevent extra queries this way.
                         if ($this->runwayResource->blueprint()->field($key)->fieldtype() instanceof BelongsToFieldtype) {
-                            $relationName = $this->runwayResource->eagerLoadingRelations()->get($key);
+                            $relationName = $this->runwayResource->eloquentRelationships()->get($key);
 
                             if ($record->relationLoaded($relationName)) {
                                 $value = $record->$relationName;

--- a/src/Query/Scopes/Filters/Fields/Models.php
+++ b/src/Query/Scopes/Filters/Fields/Models.php
@@ -69,7 +69,7 @@ class Models extends FieldtypeFilter
             // This is the resource of the Eloquent model that the filter is querying.
             $queryingResource = Runway::findResourceByModel($query->getModel());
 
-            $query->whereHas($queryingResource->eagerLoadingRelations()->get($this->fieldtype->field()->handle()), function (Builder $query) use ($relatedResource, $ids) {
+            $query->whereHas($queryingResource->eloquentRelationships()->get($this->fieldtype->field()->handle()), function (Builder $query) use ($relatedResource, $ids) {
                 $query->whereIn($relatedResource->primaryKey(), $ids);
             });
         } else {

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -60,11 +60,11 @@ class RunwayTag extends Tags
             $key = explode(':', (string) $where)[0];
             $value = explode(':', (string) $where)[1];
 
-            if ($resource->eagerLoadingRelations()->has($key)) {
-                // eagerLoadingRelations() return a Collection of keys/values, the keys are the field names
+            if ($resource->eloquentRelationships()->has($key)) {
+                // eloquentRelationships() returns a Collection of keys/values, the keys are the field names
                 // & the values are the Eloquent relationship names. We need to get the relationship name
                 // for the whereHas query.
-                $relationshipName = $resource->eagerLoadingRelations()->get($key);
+                $relationshipName = $resource->eloquentRelationships()->get($key);
                 $relationshipResource = Runway::findResource($resource->blueprint()->field($key)->config()['resource']);
 
                 $query->whereHas($relationshipName, function ($query) use ($value, $relationshipResource) {

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -9,19 +9,19 @@ use Statamic\Facades\Fieldset;
 class ResourceTest extends TestCase
 {
     /** @test */
-    public function can_get_eager_loading_relations_for_belongs_to_field()
+    public function can_get_eloquent_relationships_for_belongs_to_field()
     {
         Runway::discoverResources();
 
         $resource = Runway::findResource('post');
 
-        $eagerLoadingRelations = $resource->eagerLoadingRelations();
+        $eloquentRelationships = $resource->eloquentRelationships();
 
-        $this->assertContains('author', $eagerLoadingRelations->toArray());
+        $this->assertContains('author', $eloquentRelationships->toArray());
     }
 
     /** @test */
-    public function can_get_eager_loading_relations_for_has_many_field()
+    public function can_get_eloquent_relationships_for_has_many_field()
     {
         $fields = Config::get('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author.blueprint.sections.main.fields');
 
@@ -41,36 +41,36 @@ class ResourceTest extends TestCase
 
         $resource = Runway::findResource('author');
 
-        $eagerLoadingRelations = $resource->eagerLoadingRelations();
+        $eloquentRelationships = $resource->eloquentRelationships();
 
-        $this->assertContains('posts', $eagerLoadingRelations->toArray());
+        $this->assertContains('posts', $eloquentRelationships->toArray());
     }
 
     /** @test */
-    public function can_get_eager_loading_relations_for_runway_uri_routing()
+    public function can_get_eloquent_relationships_for_runway_uri_routing()
     {
         Runway::discoverResources();
 
         $resource = Runway::findResource('post');
 
-        $eagerLoadingRelations = $resource->eagerLoadingRelations();
+        $eloquentRelationships = $resource->eloquentRelationships();
 
-        $this->assertContains('runwayUri', $eagerLoadingRelations->toArray());
+        $this->assertContains('runwayUri', $eloquentRelationships->toArray());
     }
 
     /** @test */
-    public function can_get_eager_loading_relations_as_defined_in_config()
+    public function can_get_eloquent_relationships_as_defined_in_config()
     {
-        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post.with', ['author']);
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Fixtures\Models\Post.relationships', ['author']);
 
         Runway::discoverResources();
 
         $resource = Runway::findResource('post');
 
-        $eagerLoadingRelations = $resource->eagerLoadingRelations();
+        $eloquentRelationships = $resource->eloquentRelationships();
 
-        $this->assertContains('author', $eagerLoadingRelations->toArray());
-        $this->assertNotContains('runwayUri', $eagerLoadingRelations->toArray());
+        $this->assertContains('author', $eloquentRelationships->toArray());
+        $this->assertNotContains('runwayUri', $eloquentRelationships->toArray());
     }
 
     /** @test */


### PR DESCRIPTION
This pull request renames the `eagerLoadingRelations` method to `eloquentRelationships`.

## Breaking change

If you were previously overriding the "eager loaded relationships" in your resource's config array, you should change the key from `with` to `relationships`:

```php
\App\Models\Product::class => [
    // ...

    // Previously...
    'with' => ['tags', 'manufacturer'],

    // Now...
    'relationships' => ['tags', 'manufacturer'],
],
```