### PR TITLE
[6.x] Move Control Panel controllers

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -1,19 +1,19 @@
 <?php
 
-use DoubleThreeDigital\Runway\Http\Controllers\ResourceActionController;
-use DoubleThreeDigital\Runway\Http\Controllers\ResourceController;
-use DoubleThreeDigital\Runway\Http\Controllers\ResourceListingController;
+use DoubleThreeDigital\Runway\Http\Controllers\CP\ResourceActionController;
+use DoubleThreeDigital\Runway\Http\Controllers\CP\ResourceController;
+use DoubleThreeDigital\Runway\Http\Controllers\CP\ResourceListingController;
 use Illuminate\Support\Facades\Route;
 
 Route::name('runway.')->prefix('runway')->group(function () {
     Route::get('/{resource}', [ResourceController::class, 'index'])->name('index');
 
-    Route::get('/{resource}/listing-api', [ResourceListingController::class, 'index'])->name('listing-api');
-    Route::post('/{resource}/actions', [ResourceActionController::class, 'runAction'])->name('actions.run');
-    Route::post('/{resource}/actions/list', [ResourceActionController::class, 'bulkActionsList'])->name('actions.bulk');
+    Route::get('{resource}/listing-api', [ResourceListingController::class, 'index'])->name('listing-api');
+    Route::post('{resource}/actions', [ResourceActionController::class, 'runAction'])->name('actions.run');
+    Route::post('{resource}/actions/list', [ResourceActionController::class, 'bulkActionsList'])->name('actions.bulk');
 
-    Route::get('/{resource}/create', [ResourceController::class, 'create'])->name('create');
-    Route::post('/{resource}/create', [ResourceController::class, 'store'])->name('store');
-    Route::get('/{resource}/{record}', [ResourceController::class, 'edit'])->name('edit');
-    Route::patch('/{resource}/{record}', [ResourceController::class, 'update'])->name('update');
+    Route::get('{resource}/create', [ResourceController::class, 'create'])->name('create');
+    Route::post('{resource}/create', [ResourceController::class, 'store'])->name('store');
+    Route::get('{resource}/{record}', [ResourceController::class, 'edit'])->name('edit');
+    Route::patch('{resource}/{record}', [ResourceController::class, 'update'])->name('update');
 });

--- a/src/Http/Controllers/CP/ResourceActionController.php
+++ b/src/Http/Controllers/CP/ResourceActionController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Controllers;
+namespace DoubleThreeDigital\Runway\Http\Controllers\CP;
 
 use DoubleThreeDigital\Runway\Resource;
 use Illuminate\Http\Request;

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Controllers;
+namespace DoubleThreeDigital\Runway\Http\Controllers\CP;
 
 use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
 use DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;

--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -4,11 +4,11 @@ namespace DoubleThreeDigital\Runway\Http\Controllers\CP;
 
 use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
 use DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;
-use DoubleThreeDigital\Runway\Http\Requests\CreateRequest;
-use DoubleThreeDigital\Runway\Http\Requests\EditRequest;
-use DoubleThreeDigital\Runway\Http\Requests\IndexRequest;
-use DoubleThreeDigital\Runway\Http\Requests\StoreRequest;
-use DoubleThreeDigital\Runway\Http\Requests\UpdateRequest;
+use DoubleThreeDigital\Runway\Http\Requests\CP\CreateRequest;
+use DoubleThreeDigital\Runway\Http\Requests\CP\EditRequest;
+use DoubleThreeDigital\Runway\Http\Requests\CP\IndexRequest;
+use DoubleThreeDigital\Runway\Http\Requests\CP\StoreRequest;
+use DoubleThreeDigital\Runway\Http\Requests\CP\UpdateRequest;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Runway;
 use Illuminate\Database\Eloquent\Model;

--- a/src/Http/Controllers/CP/ResourceListingController.php
+++ b/src/Http/Controllers/CP/ResourceListingController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Controllers;
+namespace DoubleThreeDigital\Runway\Http\Controllers\CP;
 
 use DoubleThreeDigital\Runway\Http\Resources\ResourceCollection;
 use DoubleThreeDigital\Runway\Resource;

--- a/src/Http/Controllers/CP/Traits/HasListingColumns.php
+++ b/src/Http/Controllers/CP/Traits/HasListingColumns.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Controllers\Traits;
+namespace DoubleThreeDigital\Runway\Http\Controllers\CP\Traits;
 
 use DoubleThreeDigital\Runway\Resource;
 use Illuminate\Support\Arr;

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Controllers\Traits;
+namespace DoubleThreeDigital\Runway\Http\Controllers\CP\Traits;
 
 use Carbon\CarbonInterface;
 use DoubleThreeDigital\Runway\Fieldtypes\BelongsToFieldtype;
@@ -8,7 +8,6 @@ use DoubleThreeDigital\Runway\Fieldtypes\HasManyFieldtype;
 use DoubleThreeDigital\Runway\Resource;
 use DoubleThreeDigital\Runway\Support\Json;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;

--- a/src/Http/Requests/CP/CreateRequest.php
+++ b/src/Http/Requests/CP/CreateRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Requests;
+namespace DoubleThreeDigital\Runway\Http\Requests\CP;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
 
-class StoreRequest extends FormRequest
+class CreateRequest extends FormRequest
 {
     public function authorize()
     {

--- a/src/Http/Requests/CP/EditRequest.php
+++ b/src/Http/Requests/CP/EditRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Requests;
+namespace DoubleThreeDigital\Runway\Http\Requests\CP;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
@@ -12,10 +12,5 @@ class EditRequest extends FormRequest
         $resource = $this->route('resource');
 
         return User::current()->can('edit', $resource);
-    }
-
-    public function rules()
-    {
-        return [];
     }
 }

--- a/src/Http/Requests/CP/IndexRequest.php
+++ b/src/Http/Requests/CP/IndexRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Requests;
+namespace DoubleThreeDigital\Runway\Http\Requests\CP;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
@@ -12,10 +12,5 @@ class IndexRequest extends FormRequest
         $resource = $this->route('resource');
 
         return User::current()->can('view', $resource);
-    }
-
-    public function rules()
-    {
-        return [];
     }
 }

--- a/src/Http/Requests/CP/StoreRequest.php
+++ b/src/Http/Requests/CP/StoreRequest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Requests;
+namespace DoubleThreeDigital\Runway\Http\Requests\CP;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;
 
-class CreateRequest extends FormRequest
+class StoreRequest extends FormRequest
 {
     public function authorize()
     {
@@ -16,10 +16,5 @@ class CreateRequest extends FormRequest
         }
 
         return User::current()->can('create', $resource);
-    }
-
-    public function rules()
-    {
-        return [];
     }
 }

--- a/src/Http/Requests/CP/UpdateRequest.php
+++ b/src/Http/Requests/CP/UpdateRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Http\Requests;
+namespace DoubleThreeDigital\Runway\Http\Requests\CP;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Statamic\Facades\User;

--- a/tests/Actions/DeleteModelTest.php
+++ b/tests/Actions/DeleteModelTest.php
@@ -110,6 +110,8 @@ class DeleteModelTest extends TestCase
         $authorize = (new DeleteModel())->authorize($user, Post::factory()->create());
 
         $this->assertTrue($authorize);
+
+        Role::find('editor')->delete();
     }
 
     /** @test */

--- a/tests/Fieldtypes/BelongsToFieldtypeTest.php
+++ b/tests/Fieldtypes/BelongsToFieldtypeTest.php
@@ -181,4 +181,12 @@ class BelongsToFieldtypeTest extends TestCase
         $this->assertArrayHasKey('title', $getItemData[0]);
         $this->assertArrayNotHasKey('created_at', $getItemData[0]);
     }
+
+    /** @test */
+    public function gets_graphql_type()
+    {
+        $toGqlType = $this->fieldtype->toGqlType();
+
+        $this->assertInstanceOf(\GraphQL\Type\Definition\ObjectType::class, $toGqlType);
+    }
 }

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
+namespace DoubleThreeDigital\Runway\Tests\Http\Controllers\CP;
 
 use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;

--- a/tests/Http/Controllers/CP/ResourceListingControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceListingControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DoubleThreeDigital\Runway\Tests\Http\Controllers;
+namespace DoubleThreeDigital\Runway\Tests\Http\Controllers\CP;
 
 use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Tests\Fixtures\Models\Author;


### PR DESCRIPTION
This pull request moves Control Panel controllers into their own `CP` directory, just to keep things organised now we have both API & Control Panel controllers.