### PR TITLE
[6.x] Change "Record" terminology to "Model"

### DIFF
--- a/docs/control-panel.md
+++ b/docs/control-panel.md
@@ -151,7 +151,7 @@ class YourCustomAction extends Action
 
 ## Filters
 
-Runway provides a "Fields" filter to filter records in the Control Panel based on blueprint fields.
+Runway provides a "Fields" filter to filter models in the Control Panel based on blueprint fields.
 
 ![Control Panel Filters](/img/runway/cp-filters.png)
 

--- a/docs/kb-articles/multisite.md
+++ b/docs/kb-articles/multisite.md
@@ -25,4 +25,4 @@ public function scopeRunwayListing($query)
 
 ## Localisations
 
-Sorry, Runway doesn't support creating localisations of records as we've built Runway to be as unopinionated as possible, which introducing this feature would go against.
+Sorry, Runway doesn't support creating localisations of models as we've built Runway to be as unopinionated as possible, which introducing this feature would go against.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -155,7 +155,7 @@ You may also specify the `template` and `layout` you want to use when front-end 
 
 ### Read Only
 
-You may also specify if you want a resource to be 'read only' - eg. users will not be able to create records and when editing, all fields will be marked as read only and no save button will be displayed.
+You may also specify if you want a resource to be 'read only' - eg. users will not be able to create models and when editing, all fields will be marked as read only and no save button will be displayed.
 
 ```php
 'resources' => [

--- a/resources/js/components/Publish/PublishForm.vue
+++ b/resources/js/components/Publish/PublishForm.vue
@@ -272,7 +272,7 @@ export default {
         },
 
         /**
-         * When creating a new model via the HasMany fieldtype, pre-fill the belongs_to field to the current record.
+         * When creating a new model via the HasMany fieldtype, pre-fill the belongs_to field to the current model.
          */
         prefillBelongsToField() {
             this.values['from_inline_publish_form'] = true
@@ -284,11 +284,11 @@ export default {
                             return field.type === 'belongs_to' || field.resource === window.Runway.currentResource;
                         })
                         .forEach((field) => {
-                            let alreadyExists = this.values[field.handle].includes(window.Runway.currentRecord.id)
+                            let alreadyExists = this.values[field.handle].includes(window.Runway.currentModel.id)
 
                             if (!alreadyExists) {
-                                this.values[field.handle].push(window.Runway.currentRecord.id)
-                                this.meta[field.handle].data = [window.Runway.currentRecord]
+                                this.values[field.handle].push(window.Runway.currentModel.id)
+                                this.meta[field.handle].data = [window.Runway.currentModel]
                             }
                         })
                 })

--- a/resources/views/edit.blade.php
+++ b/resources/views/edit.blade.php
@@ -25,7 +25,7 @@
 
     <script>
         window.Runway = {
-            currentRecord: @json($currentRecord),
+            currentModel: @json($currentModel),
             currentResource: "{{ $resource->handle() }}",
         }
     </script>

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -14,6 +14,6 @@ Route::name('runway.')->prefix('runway')->group(function () {
 
     Route::get('{resource}/create', [ResourceController::class, 'create'])->name('create');
     Route::post('{resource}/create', [ResourceController::class, 'store'])->name('store');
-    Route::get('{resource}/{record}', [ResourceController::class, 'edit'])->name('edit');
-    Route::patch('{resource}/{record}', [ResourceController::class, 'update'])->name('update');
+    Route::get('{resource}/{model}', [ResourceController::class, 'edit'])->name('edit');
+    Route::patch('{resource}/{model}', [ResourceController::class, 'update'])->name('update');
 });

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -44,7 +44,7 @@ class ApiController extends StatamicApiController
         return $results;
     }
 
-    public function show($resourceHandle, $record)
+    public function show($resourceHandle, $model)
     {
         $this->abortIfDisabled();
 
@@ -56,7 +56,7 @@ class ApiController extends StatamicApiController
             throw new NotFoundHttpException;
         }
 
-        if (! $model = $resource->model()->find($record)) {
+        if (! $model = $resource->model()->find($model)) {
             throw new NotFoundHttpException;
         }
 

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -56,8 +56,8 @@ class ResourceCollection extends LaravelResourceCollection
         $handle = $this->resourceHandle;
 
         return [
-            'data' => $this->collection->map(function ($record) use ($columns, $handle) {
-                $row = $record->toArray();
+            'data' => $this->collection->map(function ($model) use ($columns, $handle) {
+                $row = $model->toArray();
 
                 foreach ($row as $key => $value) {
                     if (! in_array($key, $columns)) {
@@ -70,16 +70,16 @@ class ResourceCollection extends LaravelResourceCollection
                         if ($this->runwayResource->blueprint()->field($key)->fieldtype() instanceof BelongsToFieldtype) {
                             $relationName = $this->runwayResource->eloquentRelationships()->get($key);
 
-                            if ($record->relationLoaded($relationName)) {
-                                $value = $record->$relationName;
+                            if ($model->relationLoaded($relationName)) {
+                                $value = $model->$relationName;
                             }
                         }
 
                         if ($this->runwayResource->blueprint()->field($key)->fieldtype() instanceof HasManyFieldtype) {
                             $relationName = $key;
 
-                            if ($record->relationLoaded($relationName)) {
-                                $value = $record->$relationName;
+                            if ($model->relationLoaded($relationName)) {
+                                $value = $model->$relationName;
                             }
                         }
 
@@ -90,15 +90,15 @@ class ResourceCollection extends LaravelResourceCollection
                 foreach ($this->runwayResource->blueprint()->fields()->except(array_keys($row))->all() as $fieldHandle => $field) {
                     $key = str_replace('->', '.', $fieldHandle);
 
-                    $row[$fieldHandle] = $field->setValue(data_get($record, $key))->preProcessIndex()->value();
+                    $row[$fieldHandle] = $field->setValue(data_get($model, $key))->preProcessIndex()->value();
                 }
 
-                $row['id'] = $record->getKey();
-                $row['edit_url'] = cp_route('runway.edit', ['resource' => $handle, 'record' => $record->getRouteKey()]);
-                $row['permalink'] = $this->runwayResource->hasRouting() ? $record->uri() : null;
+                $row['id'] = $model->getKey();
+                $row['edit_url'] = cp_route('runway.edit', ['resource' => $handle, 'model' => $model->getRouteKey()]);
+                $row['permalink'] = $this->runwayResource->hasRouting() ? $model->uri() : null;
                 $row['editable'] = User::current()->can('edit', $this->runwayResource);
                 $row['viewable'] = User::current()->can('view', $this->runwayResource);
-                $row['actions'] = Action::for($record, ['resource' => $this->runwayResource->handle()]);
+                $row['actions'] = Action::for($model, ['resource' => $this->runwayResource->handle()]);
 
                 return $row;
             }),

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -189,7 +189,7 @@ class ServiceProvider extends AddonServiceProvider
                     ->prefix(config('statamic.api.route'))
                     ->group(function () {
                         Route::name('runway.index')->get('runway/{resourceHandle}', [ApiController::class, 'index']);
-                        Route::name('runway.show')->get('runway/{resourceHandle}/{record}', [ApiController::class, 'show']);
+                        Route::name('runway.show')->get('runway/{resourceHandle}/{model}', [ApiController::class, 'show']);
                     });
             });
         }

--- a/src/Tags/RunwayTag.php
+++ b/src/Tags/RunwayTag.php
@@ -108,22 +108,22 @@ class RunwayTag extends Tags
         }
 
         if (! $this->params->has('as')) {
-            return $this->augmentRecords($results, $resource);
+            return $this->augmentModels($results, $resource);
         }
 
         return [
-            $this->params->get('as') => $this->augmentRecords($results, $resource),
+            $this->params->get('as') => $this->augmentModels($results, $resource),
             'paginate' => isset($paginator) ? $this->getPaginationData($paginator) : null,
             'no_results' => collect($results)->isEmpty(),
         ];
     }
 
-    protected function augmentRecords($query, Resource $resource): array
+    protected function augmentModels($query, Resource $resource): array
     {
         return collect($query)
-            ->map(function ($record, $key) use ($resource) {
-                return Blink::once("Runway::Tag::AugmentRecords::{$resource->handle()}::{$record->{$resource->primaryKey()}}", function () use ($record) {
-                    return $record->toAugmentedArray();
+            ->map(function ($model, $key) use ($resource) {
+                return Blink::once("Runway::Tag::AugmentModels::{$resource->handle()}::{$model->{$resource->primaryKey()}}", function () use ($model) {
+                    return $model->toAugmentedArray();
                 });
             })
             ->toArray();

--- a/tests/Fieldtypes/HasManyFieldtypeTest.php
+++ b/tests/Fieldtypes/HasManyFieldtypeTest.php
@@ -205,7 +205,7 @@ class HasManyFieldtypeTest extends TestCase
         // Usually these bits would be fetched from the request. However, as we can't mock
         // the request, we're using Blink.
         Blink::put('RunwayRouteResource', 'author');
-        Blink::put('RunwayRouteRecord', $author->id);
+        Blink::put('RunwayRouteModel', $author->id);
 
         $this->fieldtype->process(collect($posts)->pluck('id')->toArray());
 
@@ -231,7 +231,7 @@ class HasManyFieldtypeTest extends TestCase
         // Usually these bits would be fetched from the request. However, as we can't mock
         // the request, we're using Blink.
         Blink::put('RunwayRouteResource', 'author');
-        Blink::put('RunwayRouteRecord', $author->id);
+        Blink::put('RunwayRouteModel', $author->id);
 
         $this->fieldtypeUsingPivotTable->process([
             $posts[0]->id,
@@ -270,7 +270,7 @@ class HasManyFieldtypeTest extends TestCase
         // Usually these bits would be fetched from the request. However, as we can't mock
         // the request, we're using Blink.
         Blink::put('RunwayRouteResource', 'author');
-        Blink::put('RunwayRouteRecord', $author->id);
+        Blink::put('RunwayRouteModel', $author->id);
 
         $this->fieldtype->process([
             $posts[1]->id,
@@ -317,7 +317,7 @@ class HasManyFieldtypeTest extends TestCase
         // Usually these bits would be fetched from the request. However, as we can't mock
         // the request, we're using Blink.
         Blink::put('RunwayRouteResource', 'author');
-        Blink::put('RunwayRouteRecord', $author->id);
+        Blink::put('RunwayRouteModel', $author->id);
 
         $this->fieldtypeUsingPivotTable->process([
             $posts[1]->id,

--- a/tests/Http/Controllers/ApiControllerTest.php
+++ b/tests/Http/Controllers/ApiControllerTest.php
@@ -46,7 +46,7 @@ class ApiControllerTest extends TestCase
         $post = Post::factory()->create();
 
         $this
-            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'record' => $post->id]))
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'model' => $post->id]))
             ->assertOk()
             ->assertSee(['data'])
             ->assertJsonPath('data.id', $post->id)
@@ -64,7 +64,7 @@ class ApiControllerTest extends TestCase
         ]);
 
         $this
-            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'record' => $post->id]))
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'model' => $post->id]))
             ->assertOk()
             ->assertSee(['data'])
             ->assertJsonPath('data.id', $post->id)
@@ -79,7 +79,7 @@ class ApiControllerTest extends TestCase
         $post = Post::factory()->create();
 
         $this
-            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'record' => $post->id]))
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'model' => $post->id]))
             ->assertOk()
             ->assertSee(['data'])
             ->assertJsonPath('data.id', $post->id)
@@ -91,7 +91,7 @@ class ApiControllerTest extends TestCase
     public function returns_not_found_on_a_model_that_does_not_exist()
     {
         $this
-            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'record' => 44]))
+            ->get(route('statamic.api.runway.show', ['resourceHandle' => 'posts', 'model' => 44]))
             ->assertNotFound();
     }
 

--- a/tests/Http/Controllers/CP/ResourceControllerTest.php
+++ b/tests/Http/Controllers/CP/ResourceControllerTest.php
@@ -255,7 +255,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => $post->id]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'model' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
             ->assertSee($post->body);
@@ -268,7 +268,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => 12345]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'model' => 12345]))
             ->assertNotFound()
             ->assertSee('Page Not Found');
     }
@@ -296,15 +296,15 @@ class ResourceControllerTest extends TestCase
         $post = Post::factory()->create();
 
         $resource = Runway::findResource('post');
-        $record = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
+        $model = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
 
-        $this->assertEquals($post->getKey(), $record->getKey());
+        $this->assertEquals($post->getKey(), $model->getKey());
 
         $response = $this
             ->actingAs($user)
             ->get(cp_route('runway.edit', [
                 'resource' => 'post',
-                'record' => $post->id,
+                'model' => $post->id,
             ]))
             ->assertOk();
 
@@ -341,15 +341,15 @@ class ResourceControllerTest extends TestCase
         $user = User::make()->makeSuper()->save();
 
         $resource = Runway::findResource('post');
-        $record = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
+        $model = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
 
-        $this->assertEquals($post->getKey(), $record->getKey());
+        $this->assertEquals($post->getKey(), $model->getKey());
 
         $response = $this
             ->actingAs($user)
             ->get(cp_route('runway.edit', [
                 'resource' => 'post',
-                'record' => $post->id,
+                'model' => $post->id,
             ]))
             ->assertOk();
 
@@ -386,15 +386,15 @@ class ResourceControllerTest extends TestCase
         $user = User::make()->makeSuper()->save();
 
         $resource = Runway::findResource('post');
-        $record = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
+        $model = $resource->model()->where($resource->routeKey(), $post->getKey())->first();
 
-        $this->assertEquals($post->getKey(), $record->getKey());
+        $this->assertEquals($post->getKey(), $model->getKey());
 
         $response = $this
             ->actingAs($user)
             ->get(cp_route('runway.edit', [
                 'resource' => 'post',
-                'record' => $post->id,
+                'model' => $post->id,
             ]))
             ->assertOk();
 
@@ -423,7 +423,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => $post->id]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'model' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
             ->assertSee($post->body)
@@ -442,7 +442,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => $post->id]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'model' => $post->id]))
             ->assertOk()
             ->assertSee($post->title)
             ->assertSee($post->body);
@@ -466,7 +466,7 @@ class ResourceControllerTest extends TestCase
         $user = User::make()->makeSuper()->save();
 
         $this->actingAs($user)
-            ->get(cp_route('runway.edit', ['resource' => 'post', 'record' => $post->id]))
+            ->get(cp_route('runway.edit', ['resource' => 'post', 'model' => $post->id]))
             ->assertOk()
             ->assertSee($post->external_links->links[0]->label)
             ->assertSee($post->external_links->links[1]->url);
@@ -480,7 +480,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -507,7 +507,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -536,7 +536,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -557,7 +557,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -585,7 +585,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -613,7 +613,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,
@@ -641,7 +641,7 @@ class ResourceControllerTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->patch(cp_route('runway.update', ['resource' => 'post', 'record' => $post->id]), [
+            ->patch(cp_route('runway.update', ['resource' => 'post', 'model' => $post->id]), [
                 'title' => 'Santa is coming home',
                 'slug' => 'santa-is-coming-home',
                 'body' => $post->body,

--- a/tests/Tags/RunwayTagTest.php
+++ b/tests/Tags/RunwayTagTest.php
@@ -31,7 +31,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_no_parameters()
+    public function can_get_models_with_no_parameters()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -48,7 +48,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_select_parameter()
+    public function can_get_models_with_select_parameter()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -82,7 +82,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_scope_parameter()
+    public function can_get_models_with_scope_parameter()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -103,7 +103,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_scope_parameter_and_scope_arguments()
+    public function can_get_models_with_scope_parameter_and_scope_arguments()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -126,7 +126,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_scope_parameter_and_scope_arguments_and_multiple_scopes()
+    public function can_get_models_with_scope_parameter_and_scope_arguments_and_multiple_scopes()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -149,7 +149,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_where_parameter()
+    public function can_get_models_with_where_parameter()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -166,7 +166,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_where_parameter_when_condition_is_on_relationship_field()
+    public function can_get_models_with_where_parameter_when_condition_is_on_relationship_field()
     {
         $posts = Post::factory()->count(5)->create();
         $author = Author::factory()->create();
@@ -188,7 +188,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_with_parameter()
+    public function can_get_models_with_with_parameter()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -208,7 +208,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_sort_parameter()
+    public function can_get_models_with_sort_parameter()
     {
         $posts = Post::factory()->count(2)->create();
 
@@ -228,7 +228,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_scoping()
+    public function can_get_models_with_scoping()
     {
         $posts = Post::factory()->count(2)->create();
 
@@ -248,7 +248,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_limit_parameter()
+    public function can_get_models_with_limit_parameter()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -267,7 +267,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_scoping_and_pagination()
+    public function can_get_models_with_scoping_and_pagination()
     {
         $posts = Post::factory()->count(5)->create();
 
@@ -290,7 +290,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_and_non_blueprint_columns_are_returned()
+    public function can_get_models_and_non_blueprint_columns_are_returned()
     {
         $posts = Post::factory()->count(2)->create();
 
@@ -308,7 +308,7 @@ class RunwayTagTest extends TestCase
     }
 
     /** @test */
-    public function can_get_records_with_studly_case_resource_handle()
+    public function can_get_models_with_studly_case_resource_handle()
     {
         Config::set('runway.resources.'.Post::class.'.handle', 'BlogPosts');
 


### PR DESCRIPTION
This pull request changes the terminology Runway uses to refer to records/rows/items/models in the database.

Previously, they've been referred to as "records". However, to simplify things, they're now referred to as "models".

