### PR TITLE
[5.x] Fix search supplements

### DIFF
--- a/src/Data/AugmentedModel.php
+++ b/src/Data/AugmentedModel.php
@@ -6,6 +6,7 @@ use Carbon\CarbonInterface;
 use DoubleThreeDigital\Runway\Runway;
 use DoubleThreeDigital\Runway\Support\Json;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Statamic\Data\AbstractAugmented;
 use Statamic\Fields\Blueprint;
 
@@ -15,15 +16,16 @@ class AugmentedModel extends AbstractAugmented
 
     protected $resource;
 
-    protected $supplements = [];
+    protected $supplements;
 
     public function __construct($model)
     {
         $this->data = $model;
         $this->resource = Runway::findResourceByModel($model);
+        $this->supplements = collect();
     }
 
-    public function supplement(array $data)
+    public function supplement(Collection $data)
     {
         $this->supplements = $data;
 
@@ -116,6 +118,6 @@ class AugmentedModel extends AbstractAugmented
 
     protected function getFromData($handle)
     {
-        return $this->supplements[$handle] ?? $this->data->$handle;
+        return $this->supplements->get($handle) ?? $this->data->$handle;
     }
 }

--- a/src/Search/Searchable.php
+++ b/src/Search/Searchable.php
@@ -26,6 +26,7 @@ class Searchable implements Augmentable, ContainsQueryableValues, Contract
     {
         $this->model = $model;
         $this->resource = Runway::findResourceByModel($model);
+        $this->supplements = collect();
     }
 
     public function resource()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ use Statamic\Statamic;
 
 abstract class TestCase extends OrchestraTestCase
 {
-    use DatabaseMigrations, RefreshDatabase, WithFaker;
+    use RefreshDatabase, WithFaker;
 
     protected $shouldFakeVersion = true;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,7 +7,6 @@ use DoubleThreeDigital\Runway\ServiceProvider;
 use DoubleThreeDigital\Runway\Traits\HasRunwayResource;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Encryption\Encrypter;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;


### PR DESCRIPTION
This pull request fixes an issue relating to supplements & search.

It ensures `$supplements` is always an empty `Collection` & ensures that we're passing in a collection, rather than an array to the `AugmentedModel@supplement` method.

Fixes #376.