### PR TITLE
[5.x] Fix fields parent not being passed on publish forms

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -217,7 +217,7 @@ class ResourceController extends CpController
         }
 
         $blueprint = $resource->blueprint();
-        $fields = $blueprint->fields()->addValues($values)->preProcess();
+        $fields = $blueprint->fields()->setParent($record)->addValues($values)->preProcess();
 
         $viewData = [
             'title' => __('Edit :resource', [
@@ -265,6 +265,7 @@ class ResourceController extends CpController
         Runway::findResource($resourceHandle)
             ->blueprint()
             ->fields()
+            ->setParent($record)
             ->addValues($request->all())
             ->validator()
             ->validate();


### PR DESCRIPTION
This pull request fixes an issue where Runway wasn't passing the Eloquent model as the "parent" into the fields when on publish form pages.

The `parent` can be helpful when developing custom fieldtype as it provides some context about the "thing" thats being edited.

Fixes #379.