### PR TITLE
[6.x] Ensure parent is passed into fields in publish forms

### DIFF
--- a/src/Http/Controllers/CP/ResourceController.php
+++ b/src/Http/Controllers/CP/ResourceController.php
@@ -126,7 +126,7 @@ class ResourceController extends CpController
         $values = $this->prepareModelForPublishForm($resource, $model);
 
         $blueprint = $resource->blueprint();
-        $fields = $blueprint->fields()->addValues($values)->preProcess();
+        $fields = $blueprint->fields()->setParent($model)->addValues($values)->preProcess();
 
         $viewData = [
             'title' => __('Edit :resource', ['resource' => $resource->singular()]),
@@ -163,7 +163,7 @@ class ResourceController extends CpController
 
     public function update(UpdateRequest $request, Resource $resource, $model)
     {
-        $resource->blueprint()->fields()->addValues($request->all())->validator()->validate();
+        $resource->blueprint()->fields()->setParent($model)->addValues($request->all())->validator()->validate();
 
         $model = $resource->model()->where($resource->model()->qualifyColumn($resource->routeKey()), $model)->first();
 

--- a/src/Http/Controllers/CP/Traits/PreparesModels.php
+++ b/src/Http/Controllers/CP/Traits/PreparesModels.php
@@ -61,7 +61,7 @@ trait PreparesModels
     {
         $blueprint = $resource->blueprint();
 
-        $blueprint->fields()->all()
+        $blueprint->fields()->setParent($model)->all()
             ->filter(fn (Field $field) => $this->shouldSaveField($field))
             ->each(function (Field $field) use (&$model, $request) {
                 $processedValue = $field->fieldtype()->process($request->get($field->handle()));


### PR DESCRIPTION
This pull request fixes an issue where Runway wasn't passing the Eloquent model as the "parent" into the fields when on publish form pages.

The `parent` can be helpful when developing custom fieldtype as it provides some context about the "thing" thats being edited.

Mirrors #381 but for v6.