### PR TITLE
[5.x] Pass model to the policy

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,7 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
+    beStrictAboutTestsThatDoNotTestAnything="false"
 >
     <testsuites>
         <testsuite name="Test Suite">

--- a/src/Actions/DeleteModel.php
+++ b/src/Actions/DeleteModel.php
@@ -35,7 +35,7 @@ class DeleteModel extends Action
     {
         $resource = Runway::findResourceByModel($item);
 
-        return $user->can('delete', $resource);
+        return $user->can('delete', [$resource, $item]);
     }
 
     public function buttonText()

--- a/src/Fieldtypes/BaseFieldtype.php
+++ b/src/Fieldtypes/BaseFieldtype.php
@@ -309,8 +309,8 @@ class BaseFieldtype extends Relationship
                     'id' => $record->{$resource->primaryKey()},
                     'title' => $this->makeTitle($record, $resource),
                     'edit_url' => $editUrl,
-                    'editable' => User::current()->can('edit', $resource),
-                    'viewable' => User::current()->can('view', $resource),
+                    'editable' => User::current()->can('edit', [$resource, $record]),
+                    'viewable' => User::current()->can('view', [$resource, $record]),
                     'actions' => Action::for($record, ['resource' => $resource->handle()])->reject(fn ($action) => $action instanceof DeleteModel)->toArray(),
                 ])
                 ->toArray();

--- a/src/Http/Requests/EditRequest.php
+++ b/src/Http/Requests/EditRequest.php
@@ -12,7 +12,9 @@ class EditRequest extends FormRequest
     {
         $resource = Runway::findResource($this->resourceHandle);
 
-        return User::current()->can('edit', $resource);
+        $model = $resource->model()::find($this->record);
+
+        return User::current()->can('edit', [$resource, $model]);
     }
 
     public function rules()

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -16,6 +16,8 @@ class UpdateRequest extends FormRequest
             return false;
         }
 
-        return User::current()->can('edit', $resource);
+        $model = $resource->model()::find($this->record);
+
+        return User::current()->can('edit', [$resource, $model]);
     }
 }

--- a/src/Http/Requests/UpdateRequest.php
+++ b/src/Http/Requests/UpdateRequest.php
@@ -16,7 +16,7 @@ class UpdateRequest extends FormRequest
             return false;
         }
 
-        $model = $resource->model()::find($this->record);
+        $model = $resource->model()->find($this->record);
 
         return User::current()->can('edit', [$resource, $model]);
     }

--- a/src/Http/Resources/ResourceCollection.php
+++ b/src/Http/Resources/ResourceCollection.php
@@ -96,8 +96,8 @@ class ResourceCollection extends LaravelResourceCollection
                 $row['id'] = $record->getKey();
                 $row['edit_url'] = cp_route('runway.edit', ['resourceHandle' => $handle, 'record' => $record->getRouteKey()]);
                 $row['permalink'] = $this->runwayResource->hasRouting() ? $record->uri() : null;
-                $row['editable'] = User::current()->can('edit', $this->runwayResource);
-                $row['viewable'] = User::current()->can('view', $this->runwayResource);
+                $row['editable'] = User::current()->can('edit', [$this->runwayResource, $record]);
+                $row['viewable'] = User::current()->can('view', [$this->runwayResource, $record]);
                 $row['actions'] = Action::for($record, ['resource' => $this->runwayResource->handle()]);
 
                 return $row;

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -7,25 +7,25 @@ use Statamic\Facades\User;
 
 class ResourcePolicy
 {
-    public function view($user, Resource $resource)
+    public function view($user, Resource $resource, $model = null)
     {
         return User::fromUser($user)
             ->hasPermission("view {$resource->handle()}");
     }
 
-    public function create($user, Resource $resource)
+    public function create($user, Resource $resource, $model = null)
     {
         return User::fromUser($user)
             ->hasPermission("create {$resource->handle()}");
     }
 
-    public function edit($user, Resource $resource)
+    public function edit($user, Resource $resource, $model = null)
     {
         return User::fromUser($user)
             ->hasPermission("edit {$resource->handle()}");
     }
 
-    public function delete($user, Resource $resource)
+    public function delete($user, Resource $resource, $model = null)
     {
         return User::fromUser($user)
             ->hasPermission("delete {$resource->handle()}");

--- a/src/Policies/ResourcePolicy.php
+++ b/src/Policies/ResourcePolicy.php
@@ -13,7 +13,7 @@ class ResourcePolicy
             ->hasPermission("view {$resource->handle()}");
     }
 
-    public function create($user, Resource $resource, $model = null)
+    public function create($user, Resource $resource)
     {
         return User::fromUser($user)
             ->hasPermission("create {$resource->handle()}");

--- a/tests/Policies/ResourcePolicyTest.php
+++ b/tests/Policies/ResourcePolicyTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace DoubleThreeDigital\Runway\Tests\Policies;
+
+use DoubleThreeDigital\Runway\Runway;
+use DoubleThreeDigital\Runway\Tests\Post;
+use DoubleThreeDigital\Runway\Tests\TestCase;
+use Statamic\Facades\Role;
+use Statamic\Facades\User;
+
+class ResourcePolicyTest extends TestCase
+{
+    /** @test */
+    public function can_view_resource()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('view post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('view', $resource));
+    }
+
+    /** @test */
+    public function can_view_resource_with_model()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('view post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('view', [$resource, new Post]));
+    }
+
+    /** @test */
+    public function can_create_resource()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('create post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('create', $resource));
+    }
+
+    public function can_edit_resource()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('edit post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('edit', $resource));
+    }
+
+    /** @test */
+    public function can_edit_resource_with_model()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('edit post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('edit', [$resource, new Post]));
+    }
+
+    public function can_delete_resource()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('delete post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('delete', $resource));
+    }
+
+    /** @test */
+    public function can_delete_resource_with_model()
+    {
+        $resource = Runway::findResource('post');
+
+        Role::make('test')->addPermission('delete post')->save();
+        $user = User::make()->assignRole('test')->save();
+
+        $this->assertTrue($user->can('delete', [$resource, new Post]));
+    }
+}


### PR DESCRIPTION
The `ResourcePolicy` needs the actual model, in case there's logic that requires it.