### PR TITLE
[5.x] Add support to display statamic widgets on resource index page

### DIFF
--- a/config/runway.php
+++ b/config/runway.php
@@ -15,6 +15,14 @@ return [
         // \App\Models\Order::class => [
         //     'name' => 'Orders',
 
+        // 'widgets' => [
+        //    [
+        //        'type' => 'collection',
+        //        'collection' => 'pages',
+        //        'width' => 50
+        //    ],
+        // ],
+
         //     'blueprint' => [
         //         'tabs' => [
         //             'main' => [

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -184,7 +184,7 @@ Sometimes you may want to change the order that your models are returned in the 
 
 ### Title field
 
-When Runway displays models inside inside the Control Panel (eg. in relationship fields, in search), it'll default to showing the first listable field it can find, based on your blueprint.
+When Runway displays models inside the Control Panel (eg. in relationship fields, in search), it'll default to showing the first listable field it can find, based on your blueprint.
 
 If you'd like to specify a different field, you may do so by setting the `title_field` option on your resource.
 
@@ -193,6 +193,34 @@ If you'd like to specify a different field, you may do so by setting the `title_
 	\App\Models\Order::class => [
 	    'name' => 'Orders',
 		'title_field' => 'name',
+	],
+],
+```
+
+### Statamic Widgets
+
+Runway can also display [Statamic widgets](https://statamic.dev/reference/widgets) on your resources index page, you are free to use first party widget comes with statamic and can also [create your own widget](https://statamic.dev/extending/widgets) to show for example stats for orders.
+
+You can add configuration for `widgets` element on your resource.
+
+```php
+'resources' => [
+	\App\Models\Order::class => [
+	    'name' => 'Orders',
+	    
+	    // define all widgets for order resource
+		'widgets' => [
+                [
+                    'type' => 'earning',
+                    'width' => 50
+                ],
+                [
+                    'type' => 'collection',
+                    'collection' => 'pages',
+                    'width' => 50
+                ],
+            ],
+        ],
 	],
 ],
 ```

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -3,6 +3,14 @@
 @section('wrapper_class', 'max-w-full')
 
 @section('content')
+    <div class="widgets @container flex flex-wrap -mx-4 py-2">
+        @foreach($widgets as $widget)
+            <div class="widget w-full md:{{ Statamic\Support\Str::tailwindWidthClass($widget['width']) }} {{ $widget['classes'] }} mb-8 px-4">
+                {!! $widget['html'] !!}
+            </div>
+        @endforeach
+    </div>
+
     <div class="flex items-center justify-between mb-6">
         <h1 class="flex-1">{{ $title }}</h1>
 

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -37,7 +37,7 @@ class ResourceControllerTest extends TestCase
             [
                 'type' => 'collection',
                 'collection' => 'pages',
-                'width' => 50
+                'width' => 50,
             ],
         ]);
 

--- a/tests/Http/Controllers/ResourceControllerTest.php
+++ b/tests/Http/Controllers/ResourceControllerTest.php
@@ -31,6 +31,33 @@ class ResourceControllerTest extends TestCase
     }
 
     /** @test */
+    public function get_model_index_widgets()
+    {
+        Config::set('runway.resources.'.Post::class.'.widgets', [
+            [
+                'type' => 'collection',
+                'collection' => 'pages',
+                'width' => 50
+            ],
+        ]);
+
+        Runway::discoverResources();
+
+        $user = User::make()->makeSuper()->save();
+
+        $posts = $this->postFactory(2);
+
+        $this->actingAs($user)
+            ->get(cp_route('runway.index', ['resourceHandle' => 'post']))
+            ->assertOk()
+            ->assertViewIs('runway::index')
+            ->assertSee([
+                'widgets',
+                'columns',
+            ]);
+    }
+
+    /** @test */
     public function can_create_resource()
     {
         $user = User::make()->makeSuper()->save();


### PR DESCRIPTION
This PR adds support for statamic widgets to be displayed on top of resource index page similar to Nova. To add a widget you just need to add widgets on resource configuration.

```php
'resources' => [
	\App\Models\Order::class => [
	    'name' => 'Orders',
	    
	    // define all widgets for order resource
		'widgets' => [
                [
                    'type' => 'earning',
                    'width' => 50
                ],
                [
                    'type' => 'collection',
                    'collection' => 'pages',
                    'width' => 50
                ],
            ],
        ],
    ],
],
```

![Screenshot 2023-12-16 at 10 05 15 AM](https://github.com/duncanmcclean/runway/assets/6937224/e54b4b6a-ed0c-45ef-bf3b-ecb5f1d8a2f8)
