### PR TITLE
[5.x] Fix `unique` validation rule

### DIFF
--- a/src/Http/Controllers/ResourceController.php
+++ b/src/Http/Controllers/ResourceController.php
@@ -268,6 +268,9 @@ class ResourceController extends CpController
             ->setParent($record)
             ->addValues($request->all())
             ->validator()
+            ->withReplacements([
+                $resource->primaryKey() => $record,
+            ])
             ->validate();
 
         $record = $resource->model()


### PR DESCRIPTION
This pull request fixes an issue when using Laravel's [`unique`](https://laravel.com/docs/master/validation#rule-unique) validation rule. 

Runway didn't provide the model's ID as a "replacement" value so the current model couldn't be excluded from the validation.

Fixes #385.