### PR TITLE
[5.x] Bug: Missing hidden fields in listableColumns

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -279,7 +279,6 @@ class Resource
         return $this->blueprint()->fields()->items()
             ->reject(function ($field) {
                 return isset($field['import'])
-                    || (isset($field['field']['listable']) && $field['field']['listable'] === 'hidden')
                     || (isset($field['field']['listable']) && $field['field']['listable'] === false);
             })
             ->pluck('handle')

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -217,7 +217,19 @@ class Resource
     {
         return $this
             ->fluentlyGetOrSet('titleField')
-            ->getter(fn ($field) => $field ?? $this->listableColumns()[0])
+            ->getter(function ($field) {
+                if (! $field) {
+                    return collect($this->listableColumns())
+                        ->reject(function ($handle) {
+                            $field = $this->blueprint()->field($handle);
+
+                            return $field->get('listable') && $field->get('listable') === 'hidden';
+                        })
+                        ->first();
+                }
+
+                return $field;
+            })
             ->args(func_get_args());
     }
 

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -123,4 +123,40 @@ class ResourceTest extends TestCase
 
         $this->assertSame($plural, 'Bibliotheken');
     }
+
+    /** @test */
+    public function can_get_listable_columns()
+    {
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.blueprint.sections.main.fields', [
+            [
+                'handle' => 'values->normal_field',
+                'field' => ['type' => 'text'],
+            ],
+            [
+                'handle' => 'values->listable_hidden_field',
+                'field' => ['type' => 'text', 'listable' => 'hidden'],
+            ],
+            [
+                'handle' => 'values->listable_shown_field',
+                'field' => ['type' => 'text', 'listable' => true],
+            ],
+            [
+                'handle' => 'values->not_listable_field',
+                'field' => ['type' => 'text', 'listable' => false],
+            ],
+        ]);
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $listableColumns = $resource->listableColumns();
+
+        $this->assertCount(3, $listableColumns);
+        $this->assertEquals([
+            'values->normal_field',
+            'values->listable_hidden_field',
+            'values->listable_shown_field',
+        ], $listableColumns);
+    }
 }

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -159,4 +159,29 @@ class ResourceTest extends TestCase
             'values->listable_shown_field',
         ], $listableColumns);
     }
+
+    /** @test */
+    public function can_get_title_field()
+    {
+        Config::set('runway.resources.DoubleThreeDigital\Runway\Tests\Post.blueprint.sections.main.fields', [
+            [
+                'handle' => 'values->listable_hidden_field',
+                'field' => ['type' => 'text', 'listable' => 'hidden'],
+            ],
+            [
+                'handle' => 'values->listable_shown_field',
+                'field' => ['type' => 'text', 'listable' => true],
+            ],
+            [
+                'handle' => 'values->not_listable_field',
+                'field' => ['type' => 'text', 'listable' => false],
+            ],
+        ]);
+
+        Runway::discoverResources();
+
+        $resource = Runway::findResource('post');
+
+        $this->assertEquals('values->listable_shown_field', $resource->titleField());
+    }
 }


### PR DESCRIPTION
Fixes #392. Currently, if you mark a field as `hidden`, the second qualifier in the `listableColumns` method of `Resource.php` (noted below) causes it to be rejected. That is, it does not show up in the "column picker" of the control panel's index view:

```php 
/**
 * Returns an array of column handles that are marked as listable.
 */
public function listableColumns(): array
{
  return $this->blueprint()->fields()->items()
    ->reject(function ($field) {
      return isset($field['import'])
        // ❌ This PR removes the following line, to avoid rejecting hidden fields:
        || (isset($field['field']['listable']) && $field['field']['listable'] === 'hidden') 
        || (isset($field['field']['listable']) && $field['field']['listable'] === false);
      })
    ->pluck('handle')
    ->toArray();
}
```

This PR makes "column availability" on the index page behave like standard blueprints in Statamic. Here's [a snippet from the docs](https://statamic.dev/blueprints#unlisted-fields): 

> This will hide the field from entry listings by default, but still allows a user to toggle visibility using the column selector, and save those column preferences for his/her preferred workflow.

Let me know if I've missed anything here, or if this is intended behavior for any reason. Thanks Duncan!

Thanks!